### PR TITLE
Feature/performance enhancement: Message Caching

### DIFF
--- a/extensions/ezmsg-sigproc/tests/test_window.py
+++ b/extensions/ezmsg-sigproc/tests/test_window.py
@@ -70,12 +70,6 @@ class WindowSystem(ez.System):
 
         )
 
-    # These tests complete quickly, sometimes all processes aren't ready
-    # when ez.NormalTermination is raised, which causes system to hang
-    # FIXME #3
-    # def process_components( self ) -> Tuple[ ez.Component, ... ]:
-    #     return ( self.OSC, self.WIN, self.LOG, self.TERM )
-
 
 @pytest.mark.parametrize("block_size", [1, 5, 10, 20])
 @pytest.mark.parametrize("win_dur", [0.2, 1.0])

--- a/ezmsg/core/backpressure.py
+++ b/ezmsg/core/backpressure.py
@@ -1,0 +1,65 @@
+import asyncio
+
+from uuid import UUID
+
+from typing import Set, Literal, List, Optional
+
+class BufferLease:
+    leases: Set[UUID] 
+    empty: asyncio.Event
+
+    def __init__(self) -> None:
+        self.leases = set()
+        self.empty= asyncio.Event()
+        self.empty.set()
+
+    def add(self, uuid: UUID) -> None:
+        self.empty.clear()
+        self.leases.add(uuid)
+
+    def discard(self, uuid: UUID) -> None:
+        self.leases.discard(uuid)
+        if len(self) == 0:
+            self.empty.set()
+
+    async def wait(self) -> Literal[True]:
+        return await self.empty.wait()
+
+    def __len__(self) -> int:
+        return len(self.leases)
+
+class Backpressure:
+    buffers: List[BufferLease]
+    empty: asyncio.Event
+
+    def __init__(self, num_buffers: int) -> None:
+        self.buffers = [BufferLease() for _ in range(num_buffers)]
+        self.empty = asyncio.Event()
+        self.empty.set()
+
+    @property
+    def pressure(self) -> int:
+        return sum(len(p) != 0 for p in self.buffers)
+
+    async def wait(self, buf_idx: int) -> None:
+        if self.pressure == len(self.buffers):
+            await self.sync()
+        else:
+            await self.buffers[buf_idx].wait()
+
+    def lease(self, uuid: UUID, buf_idx: int) -> None:
+        self.buffers[buf_idx].add(uuid)
+        self.empty.clear()
+
+    def free(self, uuid: UUID, buf_idx: Optional[int] = None) -> None:
+        if buf_idx is None:
+            for idx in range(len(self.buffers)):
+                self.buffers[idx].discard(uuid)
+        else:
+            self.buffers[buf_idx].discard(uuid)
+        
+        if self.pressure == 0:
+            self.empty.set()
+
+    async def sync(self) -> Literal[True]:
+        return await self.empty.wait()

--- a/ezmsg/core/backpressure.py
+++ b/ezmsg/core/backpressure.py
@@ -48,6 +48,7 @@ class Backpressure:
             await self.buffers[buf_idx].wait()
 
     def lease(self, uuid: UUID, buf_idx: int) -> None:
+        # print('LEASE', [len(b) for b in self.buffers])
         self.buffers[buf_idx].add(uuid)
         self.empty.clear()
 
@@ -58,6 +59,7 @@ class Backpressure:
         else:
             self.buffers[buf_idx].discard(uuid)
 
+        # print('FREE', [len(b) for b in self.buffers])
         if self.pressure == 0:
             self.empty.set()
 

--- a/ezmsg/core/backpressure.py
+++ b/ezmsg/core/backpressure.py
@@ -57,7 +57,7 @@ class Backpressure:
                 self.buffers[idx].discard(uuid)
         else:
             self.buffers[buf_idx].discard(uuid)
-        
+
         if self.pressure == 0:
             self.empty.set()
 

--- a/ezmsg/core/graphclient.py
+++ b/ezmsg/core/graphclient.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import logging
 
@@ -9,6 +10,7 @@ from .graphserver import GraphServer
 from .netprotocol import (
     Address,
     encode_str,
+    uint64_to_bytes,
     Command,
 )
 
@@ -36,6 +38,7 @@ class GraphClient:
         graph_writer.write(Command.CLIENT.value)
         graph_writer.write(self.client_type())
         graph_writer.write(encode_str(str(self.id)))
+        graph_writer.write(uint64_to_bytes(os.getpid()))
         graph_writer.write(encode_str(self.topic))
         await graph_writer.drain()
         server_connection = self._graph_server_connection(graph_reader, graph_writer)

--- a/ezmsg/core/graphclient.py
+++ b/ezmsg/core/graphclient.py
@@ -21,12 +21,14 @@ logger = logging.getLogger('ezmsg')
 
 class GraphClient:
     id: UUID
+    pid: int
     topic: str
 
     _graph_server_task: Optional[asyncio.Task] = None
 
     def __init__(self, id: UUID, topic: str) -> None:
         self.id = id
+        self.pid = os.getpid()
         self.topic = topic
 
     @staticmethod
@@ -38,7 +40,7 @@ class GraphClient:
         graph_writer.write(Command.CLIENT.value)
         graph_writer.write(self.client_type())
         graph_writer.write(encode_str(str(self.id)))
-        graph_writer.write(uint64_to_bytes(os.getpid()))
+        graph_writer.write(uint64_to_bytes(self.pid))
         graph_writer.write(encode_str(self.topic))
         await graph_writer.drain()
         server_connection = self._graph_server_connection(graph_reader, graph_writer)

--- a/ezmsg/core/graphserver.py
+++ b/ezmsg/core/graphserver.py
@@ -95,7 +95,7 @@ class GraphServer(Process):
         try:
             await server.serve_forever()
 
-        except asyncio.CancelledError:
+        except asyncio.CancelledError: # FIXME: Poor Form
             pass
         
         finally:
@@ -120,7 +120,7 @@ class GraphServer(Process):
             if len(req) == 0:
                 return
 
-            if req == Command.CLIENT.value:
+            elif req == Command.CLIENT.value:
                 client_type = await reader.read(1)
                 id_str = await read_str(reader)
                 id = UUID(id_str)
@@ -128,7 +128,7 @@ class GraphServer(Process):
                 topic = await read_str(reader)
 
                 if id not in self._pending_clients:
-                    logger.warn('Unknown GraphClient (id: {id}) Attempted Connection')
+                    logger.warn(f'Unknown GraphClient (id: {id}) Attempted Connection')
                     return
 
                 info = ClientInfo(id, pid, topic, reader, writer)

--- a/ezmsg/core/graphserver.py
+++ b/ezmsg/core/graphserver.py
@@ -124,17 +124,18 @@ class GraphServer(Process):
                 client_type = await reader.read(1)
                 id_str = await read_str(reader)
                 id = UUID(id_str)
+                pid = await read_int(reader)
                 topic = await read_str(reader)
 
                 if id not in self._pending_clients:
                     logger.warn('Unknown GraphClient (id: {id}) Attempted Connection')
                     return
 
-                info = ClientInfo(id, topic, reader, writer)
+                info = ClientInfo(id, pid, topic, reader, writer)
                 if client_type == Command.SUBSCRIBE.value:
-                    info = SubscriberInfo(id, topic, reader, writer)
+                    info = SubscriberInfo(id, pid, topic, reader, writer)
                 elif client_type == Command.PUBLISH.value:
-                    info = PublisherInfo(id, topic, reader, writer)
+                    info = PublisherInfo(id, pid, topic, reader, writer)
 
                 self.clients[id] = info
 

--- a/ezmsg/core/messagecache.py
+++ b/ezmsg/core/messagecache.py
@@ -64,6 +64,6 @@ class Cache:
                 with MessageMarshal.obj_from_mem(mem) as obj:
                     yield obj
 
-
+# NOTE: This should be made thread-safe in the future
 MessageCache: Dict[UUID, Cache] = dict()
 

--- a/ezmsg/core/messagecache.py
+++ b/ezmsg/core/messagecache.py
@@ -38,9 +38,11 @@ class Cache:
             raise ValueError("shm has incorrect number of buffers")
 
         buf_idx = msg_id % self.num_buffers
-        with self.get(msg_id) as obj:
-            with shm.buffer(buf_idx) as mem:
-                MessageMarshal.to_mem(msg_id, obj, mem)
+        with shm.buffer(buf_idx) as mem:
+            shm_msg_id = MessageMarshal.msg_id(mem)
+            if shm_msg_id != msg_id:
+                with self.get(msg_id) as obj:
+                    MessageMarshal.to_mem(msg_id, obj, mem)
 
     @contextmanager
     def get(self, msg_id: int, shm: Optional[SHMContext] = None) -> Generator[Any, None, None]:

--- a/ezmsg/core/messagecache.py
+++ b/ezmsg/core/messagecache.py
@@ -18,13 +18,13 @@ class Cache:
     """ shared-memory backed cache for objects """
 
     num_buffers: int
-    cache: Dict[int, Any] # buf_idx to Message
-    cache_id: List[Optional[int]] # msg_ids in each cache buffer
+    cache: List[Any]
+    cache_id: List[Optional[int]]
 
     def __init__(self, num_buffers: int) -> None:
         self.num_buffers = num_buffers
         self.cache_id = [None] * self.num_buffers
-        self.cache = dict()
+        self.cache = [None] * self.num_buffers
 
     def put(self, msg_id: int, msg: Any) -> None:
         """ put an object into cache """

--- a/ezmsg/core/messagecache.py
+++ b/ezmsg/core/messagecache.py
@@ -1,0 +1,73 @@
+
+import logging
+
+from uuid import UUID
+from collections import UserDict
+from contextlib import contextmanager
+
+from .shmserver import SHMContext
+from .messagemarshal import MessageMarshal
+
+from typing import Dict, Any, Optional, List, Generator, Type
+
+logger = logging.getLogger( 'ezmsg' )
+
+class CacheMiss(Exception):
+    ...
+
+class Cache:
+    """ shared-memory backed cache for objects """
+
+    num_buffers: int
+    cache: Dict[int, Any] # buf_idx to Message
+    cache_id: List[Optional[int]] # msg_ids in each cache buffer
+
+    def __init__(self, num_buffers: int) -> None:
+        self.num_buffers = num_buffers
+        self.cache_id = [None] * self.num_buffers
+        self.cache = dict()
+
+    def put(self, msg_id: int, msg: Any) -> None:
+        """ put an object into cache """
+        buf_idx = msg_id % self.num_buffers
+        self.cache_id[buf_idx] = msg_id
+        self.cache[buf_idx] = msg
+
+    def push(self, msg_id: int, shm: SHMContext) -> None:
+        """ push an object from cache into shm """
+        if self.num_buffers != shm.num_buffers:
+            raise ValueError("shm has incorrect number of buffers")
+
+        buf_idx = msg_id % self.num_buffers
+        with self.get(msg_id) as obj:
+            with shm.buffer(buf_idx) as mem:
+                MessageMarshal.to_mem(msg_id, obj, mem)
+
+    @contextmanager
+    def get(self, msg_id: int, shm: Optional[SHMContext] = None) -> Generator[Any, None, None]:
+        """ get object from cache; if not in cache and shm provided -- get from shm """
+
+        buf_idx = msg_id % self.num_buffers
+        if self.cache_id[buf_idx] == msg_id:
+            yield self.cache[buf_idx]
+
+        else:
+            if shm is None:
+                raise CacheMiss
+            
+            with shm.buffer(buf_idx, readonly=True) as mem:
+                if MessageMarshal.msg_id(mem) != msg_id:
+                    raise CacheMiss
+
+                with MessageMarshal.obj_from_mem(mem) as obj:
+                    yield obj
+
+
+class MessageCache(UserDict[UUID, Cache]):
+
+    def __new__(cls) -> "MessageCache":
+        # Singleton Pattern
+        if not hasattr(cls, 'instance'):
+            cls.instance = super().__new__(cls)
+        return cls.instance
+

--- a/ezmsg/core/messagecache.py
+++ b/ezmsg/core/messagecache.py
@@ -2,13 +2,12 @@
 import logging
 
 from uuid import UUID
-from collections import UserDict
 from contextlib import contextmanager
 
 from .shmserver import SHMContext
 from .messagemarshal import MessageMarshal, UninitializedMemory
 
-from typing import Dict, Any, Optional, List, Generator, Type
+from typing import Dict, Any, Optional, List, Generator
 
 logger = logging.getLogger( 'ezmsg' )
 

--- a/ezmsg/core/messagemarshal.py
+++ b/ezmsg/core/messagemarshal.py
@@ -107,4 +107,10 @@ class Marshal:
     def load(buffers: List[memoryview]) -> Any:
         return pickle.loads(buffers[0], buffers = buffers[1:])
 
+    @classmethod
+    def copy_obj(cls, from_mem: memoryview, to_mem: memoryview) -> None:
+        msg_id = cls.msg_id(from_mem)
+        with MessageMarshal.obj_from_mem(from_mem) as obj:
+            MessageMarshal.to_mem(msg_id, obj, to_mem)
+
 MessageMarshal = Marshal

--- a/ezmsg/core/messagemarshal.py
+++ b/ezmsg/core/messagemarshal.py
@@ -1,0 +1,110 @@
+import pickle
+from contextlib import contextmanager
+
+from .netprotocol import uint64_to_bytes, bytes_to_uint, UINT64_SIZE
+
+from typing import Any, List, Tuple, Generator
+
+_PREAMBLE = b'EZ'
+_PREAMBLE_LEN = len(_PREAMBLE)
+
+class UndersizedMemory(Exception):
+    req_size: int
+    def __init__(self, *args: object, req_size: int = 0) -> None:
+        super().__init__(*args)
+        self.req_size = req_size
+
+class UninitializedMemory(Exception):
+    ...
+
+class Marshal:
+    """ codec for byte-level representations of objects 
+
+    This base namespace defines a marshal that uses pickle to dump
+    objects into a series of memoryviews for serialization.
+
+    It may be that serialization to a cross-platform/language format
+    is desireable in the future; in which case, this class can be
+    sub-classed and the dump/load fuctions can be overloaded.
+    """
+
+    @classmethod
+    def to_mem(cls, msg_id: int, obj: Any, mem: memoryview) -> None:
+        with cls.serialize(msg_id, obj) as ser_obj:
+            total_size, header, buffers = ser_obj
+
+            if total_size >= len(mem):
+                raise UndersizedMemory(req_size=total_size)
+
+            sidx = len(header)
+            mem[:sidx] = header[:]
+            for buf in buffers:
+                blen = len(buf)
+                mem[sidx:sidx+blen] = buf[:]
+                sidx += blen
+
+    @classmethod
+    def _assert_initialized(cls, mem: memoryview) -> None:
+        if mem[:_PREAMBLE_LEN] != _PREAMBLE:
+            raise UninitializedMemory
+
+    @classmethod
+    def msg_id(cls, mem: memoryview) -> int:
+        cls._assert_initialized(mem)
+        return bytes_to_uint(mem[_PREAMBLE_LEN:_PREAMBLE_LEN+UINT64_SIZE])
+
+    @classmethod
+    @contextmanager
+    def obj_from_mem(cls, mem: memoryview) -> Generator[Any, None, None]:
+
+        cls._assert_initialized(mem)
+
+        sidx = _PREAMBLE_LEN + UINT64_SIZE
+        num_buffers = bytes_to_uint(mem[sidx:sidx+UINT64_SIZE]); sidx += UINT64_SIZE
+        buf_sizes = [0] * num_buffers
+        for i in range(num_buffers):
+            buf_sizes[i] = bytes_to_uint(mem[sidx:sidx+UINT64_SIZE]); sidx += UINT64_SIZE
+
+        buffers: List[memoryview] = list()
+        for bsz in buf_sizes:
+            buffers.append(mem[sidx:sidx+bsz])
+            sidx += bsz
+
+        obj = cls.load(buffers)
+
+        try:
+            yield obj
+        finally:
+            del obj
+            for buf in buffers:
+                buf.release()
+
+    @classmethod
+    @contextmanager
+    def serialize(cls, msg_id: int, obj: Any) -> Generator[Tuple[int, bytes, List[memoryview]], None, None]:
+        buffers = cls.dump(obj)
+        header = uint64_to_bytes(len(buffers))
+        buf_lengths = [len(buf) for buf in buffers]
+        header_chunks = [header] + [uint64_to_bytes(b) for b in buf_lengths]
+        header = _PREAMBLE + uint64_to_bytes(msg_id) + b''.join(header_chunks)
+        header_len = len(header)
+        total_size = header_len + sum(buf_lengths)
+
+        try:
+            yield (total_size, header, buffers)
+        finally:
+            for buffer in buffers:
+                buffer.release()
+
+    @staticmethod
+    def dump(obj: Any) -> List[memoryview]:
+        obj_buffers: List[pickle.PickleBuffer] = list()
+        ser_obj = pickle.dumps(obj, protocol=5, buffer_callback=obj_buffers.append)
+        buffers = [memoryview(ser_obj)] + [b.raw() for b in obj_buffers]
+        return buffers
+
+    @staticmethod
+    def load(buffers: List[memoryview]) -> Any:
+        return pickle.loads(buffers[0], buffers = buffers[1:])
+
+MessageMarshal = Marshal

--- a/ezmsg/core/netprotocol.py
+++ b/ezmsg/core/netprotocol.py
@@ -51,6 +51,7 @@ AddressType = Union[Tuple[str, int], Address]
 @dataclass
 class ClientInfo:
     id: UUID
+    pid: int
     topic: str
     reader: asyncio.StreamReader
     writer: asyncio.StreamWriter

--- a/ezmsg/core/netprotocol.py
+++ b/ezmsg/core/netprotocol.py
@@ -114,10 +114,9 @@ class Command(enum.Enum):
     UPDATE = enum.auto()
 
     # Pub<->Sub Commands
-    MSG = enum.auto()
-    TRANSMIT = enum.auto()
-    TX_TCP = enum.auto()
+    TX_LOCAL = enum.auto()
     TX_SHM = enum.auto()
+    TX_TCP = enum.auto()
 
     # SHMServer Commands
     SHM_CREATE = enum.auto()

--- a/ezmsg/core/netprotocol.py
+++ b/ezmsg/core/netprotocol.py
@@ -112,10 +112,11 @@ class Command(enum.Enum):
     ADDRESS = enum.auto()
     UPDATE = enum.auto()
 
-    # Pub->Sub Commands
+    # Pub<->Sub Commands
+    MSG = enum.auto()
+    TRANSMIT = enum.auto()
     TX_TCP = enum.auto()
     TX_SHM = enum.auto()
-    TX_LOCAL = enum.auto()
 
     # SHMServer Commands
     SHM_CREATE = enum.auto()

--- a/ezmsg/core/pubclient.py
+++ b/ezmsg/core/pubclient.py
@@ -84,7 +84,7 @@ class Publisher(GraphClient):
         pub._connection_task.add_done_callback(on_done)
         pub._shm = await SHMContext.create(pub._num_buffers)
         pub._cache = Cache(pub._num_buffers)
-        MessageCache()[id] = pub._cache
+        MessageCache[id] = pub._cache
 
         response = await reader.read(1)
         return pub

--- a/ezmsg/core/shmserver.py
+++ b/ezmsg/core/shmserver.py
@@ -291,18 +291,11 @@ class SHMServer(Process):
 
                 finally:
                     self.shms[shm_name].leases.discard(writer)
-
-                    # FIXME: Pubs can come and go before a sub tries to attach SHM
-                    # Its possible that if we unlink right away, a sub might still want
-                    # the SHM..  There should still be a task that unlinks shms with no
-                    # leases every so often, but there's still that chance that a shm
-                    # gets unlinked between a flurry of pub messages/disconnect and a 
-                    # sub attempting to attach to the SHM.
                     
-                    # if len(self.shms[shm_name].leases) == 0:
-                    #     logger.debug(f'unlinking {shm_name}')
-                    #     self.shms[shm_name].shm.close()
-                    #     self.shms[shm_name].shm.unlink()
-                    #     del self.shms[shm_name]
+                    if len(self.shms[shm_name].leases) == 0:
+                        logger.debug(f'unlinking {shm_name}')
+                        self.shms[shm_name].shm.close()
+                        self.shms[shm_name].shm.unlink()
+                        del self.shms[shm_name]
 
                     writer.close()

--- a/ezmsg/core/shmserver.py
+++ b/ezmsg/core/shmserver.py
@@ -265,6 +265,7 @@ class SHMServer(Process):
 
                 # Create segment
                 shm = SharedMemory(size=num_buffers * buf_size, create=True)
+                shm.buf[:] = b'0' * len(shm.buf) # Guarantee zeros
                 shm.buf[0:8] = uint64_to_bytes(num_buffers)
                 shm.buf[8:16] = uint64_to_bytes(buf_size)
                 shm_name = shm.name

--- a/ezmsg/core/subclient.py
+++ b/ezmsg/core/subclient.py
@@ -159,11 +159,8 @@ class Subscriber(GraphClient):
 
                 self._incoming.put_nowait((id, msg_id))
                 
-        except ConnectionResetError:
-            logger.debug(f'Subscriber {self.id}: Publisher {id} connection reset')
-
-        except BrokenPipeError:
-            logger.debug(f'Subscriber {self.id}: Publisher {id} broken pipe')
+        except (ConnectionResetError, BrokenPipeError):
+            logger.info(f'connection fail: sub:{self.id} -> pub:{id}')
 
         finally:
             self._publishers[id].writer.close()
@@ -199,7 +196,7 @@ class Subscriber(GraphClient):
                 try:
                     await self._publishers[id].writer.drain()
                 except (BrokenPipeError, ConnectionResetError):
-                    logger.debug(f'sub:{self.id} tx fail to pub:{id}')
+                    logger.info(f'connection fail: sub:{self.id} -> pub:{id}')
 
 
             

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -184,6 +184,7 @@ def run_many_dynamic_sizes(duration, buffers) -> None:
 
 
 if __name__ == "__main__":
+
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument("--many-dynamic-sizes", action="store_true",
@@ -203,4 +204,4 @@ if __name__ == "__main__":
     if args.many_dynamic_sizes:
         run_many_dynamic_sizes(args.duration, args.num_buffers)
     else:
-        test_performance(args.duration, 8, args.num_buffers)
+        test_performance(args.duration, 2**17, args.num_buffers)

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -204,4 +204,4 @@ if __name__ == "__main__":
     if args.many_dynamic_sizes:
         run_many_dynamic_sizes(args.duration, args.num_buffers)
     else:
-        test_performance(args.duration, 2**17, args.num_buffers)
+        test_performance(args.duration, 8, args.num_buffers)


### PR DESCRIPTION
This pull request implements message caching local to each process.  Messages are assigned unique message IDs and assigned to the local message cache.  Subscribers always check the cache for the message before trying to reconstitute a version of the message from shared memory.

This enhancement makes it such that no (de)serialization or message copies are required for pubs/subs that exist together in the same process.