### PR TITLE
Fix/run components

### DIFF
--- a/ezmsg/core/backend.py
+++ b/ezmsg/core/backend.py
@@ -70,7 +70,7 @@ class ExecutionContext:
         components: typing.Mapping[str, Component],
         graph_service: GraphService,
         shm_service: SHMService,
-        root_name: str = 'ROOT',
+        root_name: typing.Optional[str] = None,
         connections: typing.Optional[NetworkDefinition] = None,
         backend_process: typing.Type[BackendProcess] = DefaultBackendProcess,
         force_single_process: bool = False,
@@ -79,7 +79,7 @@ class ExecutionContext:
 
         for name, component in components.items():
             component._set_name(name)
-            component._set_location([root_name])
+            component._set_location([root_name] if root_name is not None else [])
 
         if connections is not None:
             for from_topic, to_topic in connections:
@@ -151,7 +151,7 @@ def run_system(
 
 def run(
     components: typing.Optional[typing.Mapping[str, Component]] = None,
-    root_name: str = "ROOT",
+    root_name: typing.Optional[str] = None,
     connections: typing.Optional[NetworkDefinition] = None,
     backend_process: typing.Type[BackendProcess] = DefaultBackendProcess,
     graph_address: typing.Optional[AddressType] = None,

--- a/ezmsg/core/backend.py
+++ b/ezmsg/core/backend.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import typing
 
 from socket import socket
 from multiprocessing import Event, Barrier
@@ -23,24 +24,24 @@ from .backendprocess import (
     new_threaded_event_loop,
 )
 
-from typing import List, Callable, Tuple, Optional, Type, Set, Union, Sequence
+from .util import either_dict_or_kwargs
 
 logger = logging.getLogger("ezmsg")
 
 
 class ExecutionContext:
-    processes: List[BackendProcess]
+    processes: typing.List[BackendProcess]
     term_ev: EventType
     start_barrier: BarrierType
-    connections: List[Tuple[str, str]]
+    connections: typing.List[typing.Tuple[str, str]]
 
     def __init__(
         self,
-        processes: List[List[Unit]],
+        processes: typing.List[typing.List[Unit]],
         graph_service: GraphService,
         shm_service: SHMService,
-        connections: List[Tuple[str, str]] = [],
-        backend_process: Type[BackendProcess] = DefaultBackendProcess,
+        connections: typing.List[typing.Tuple[str, str]] = [],
+        backend_process: typing.Type[BackendProcess] = DefaultBackendProcess,
     ) -> None:
         if not processes:
             raise ValueError("Cannot create an execution context for zero processes")
@@ -66,19 +67,19 @@ class ExecutionContext:
     @classmethod
     def setup(
         cls,
-        components: List[Component],
+        components: typing.Mapping[str, Component],
         graph_service: GraphService,
         shm_service: SHMService,
-        name: Optional[str] = None,
-        connections: Optional[NetworkDefinition] = None,
-        backend_process: Type[BackendProcess] = DefaultBackendProcess,
+        root_name: str = 'ROOT',
+        connections: typing.Optional[NetworkDefinition] = None,
+        backend_process: typing.Type[BackendProcess] = DefaultBackendProcess,
         force_single_process: bool = False,
-    ) -> Optional["ExecutionContext"]:
-        graph_connections: List[Tuple[str, str]] = []
+    ) -> typing.Optional["ExecutionContext"]:
+        graph_connections: typing.List[typing.Tuple[str, str]] = []
 
-        for component in components:
+        for name, component in components.items():
             component._set_name(name)
-            component._set_location()
+            component._set_location([root_name])
 
         if connections is not None:
             for from_topic, to_topic in connections:
@@ -89,9 +90,9 @@ class ExecutionContext:
                 graph_connections.append((from_topic, to_topic))
 
         def crawl_components(
-            component: Component, callback: Callable[[Component], None]
+            component: Component, callback: typing.Callable[[Component], None]
         ) -> None:
-            search: List[Component] = [component]
+            search: typing.List[Component] = [component]
             while len(search):
                 comp = search.pop()
                 search += list(comp.components.values())
@@ -106,12 +107,12 @@ class ExecutionContext:
                         to_stream = to_stream.address
                     graph_connections.append((from_stream, to_stream))
 
-        for component in components:
+        for component in components.values():
             if isinstance(component, Collection):
                 crawl_components(component, gather_edges)
 
         processes = []
-        for component in components:
+        for component in components.values():
             if isinstance(component, Collection):
                 processes += collect_processes(component)
 
@@ -142,25 +143,28 @@ def run_system(
     system: Collection,
     num_buffers: int = 32,
     init_buf_size: int = DEFAULT_SHM_SIZE,
-    backend_process: Type[BackendProcess] = DefaultBackendProcess,
+    backend_process: typing.Type[BackendProcess] = DefaultBackendProcess,
 ) -> None:
     """Deprecated; just use run any component (unit, collection)"""
-    run(system, backend_process=backend_process)
+    run(SYSTEM = system, backend_process = backend_process)
 
 
 def run(
-    components: Union[Component, List[Component]],
-    name: Optional[str] = None,
-    connections: Optional[NetworkDefinition] = None,
-    backend_process: Type[BackendProcess] = DefaultBackendProcess,
-    graph_address: Optional[AddressType] = None,
+    components: typing.Optional[typing.Mapping[str, Component]] = None,
+    root_name: str = "ROOT",
+    connections: typing.Optional[NetworkDefinition] = None,
+    backend_process: typing.Type[BackendProcess] = DefaultBackendProcess,
+    graph_address: typing.Optional[AddressType] = None,
     force_single_process: bool = False,
+    **components_kwargs: Component
 ) -> None:
     graph_service = GraphService(graph_address)
     shm_service = SHMService()
 
-    if isinstance(components, Component):
-        components = [components]
+    components = either_dict_or_kwargs(components, components_kwargs, "run")
+
+    if components is None:
+        raise ValueError("Must supply at least one component to run")
 
     with new_threaded_event_loop() as loop:
 
@@ -168,7 +172,7 @@ def run(
             components,
             graph_service,
             shm_service,
-            name,
+            root_name,
             connections,
             backend_process,
             force_single_process,
@@ -196,7 +200,7 @@ def run(
         main_process = execution_context.processes[0]
         other_processes = execution_context.processes[1:]
 
-        sentinels: Set[Union[Connection, socket, int]] = set()
+        sentinels: typing.Set[typing.Union[Connection, socket, int]] = set()
         if other_processes:
             logger.info(f"Spinning up {len(other_processes)} extra processes.")
 
@@ -238,16 +242,16 @@ def run(
             ).result()
 
 
-def collect_processes(collection: Collection) -> List[List[Unit]]:
+def collect_processes(collection: Collection) -> typing.List[typing.List[Unit]]:
     process_units, units = _collect_processes(collection)
     if len(units):
         process_units = process_units + [units]
     return process_units
 
 
-def _collect_processes(collection: Collection) -> Tuple[List[List[Unit]], List[Unit]]:
-    process_units: List[List[Unit]] = []
-    units: List[Unit] = []
+def _collect_processes(collection: Collection) -> typing.Tuple[typing.List[typing.List[Unit]], typing.List[Unit]]:
+    process_units: typing.List[typing.List[Unit]] = []
+    units: typing.List[Unit] = []
     for comp in collection._components.values():
         if isinstance(comp, Collection):
             r_process_units, r_units = _collect_processes(comp)

--- a/ezmsg/core/util.py
+++ b/ezmsg/core/util.py
@@ -1,0 +1,40 @@
+import sys
+import typing
+
+# This content ripped from xarray
+# https://github.com/pydata/xarray/blob/8e899adcd72295a138228056643a78cac6e2de57/xarray/core/utils.py
+
+# See GH5624, this is a convoluted way to allow type-checking to use `TypeGuard` without
+# requiring typing_extensions as a required dependency to _run_ the code (it is required
+# to type-check).
+try:
+    if sys.version_info >= (3, 10):
+        from typing import TypeGuard
+    else:
+        from typing_extensions import TypeGuard
+except ImportError:
+    if typing.TYPE_CHECKING:
+        raise
+
+T = typing.TypeVar("T")
+
+def is_dict_like(value: typing.Any) -> TypeGuard[typing.Mapping]:
+    return hasattr(value, "keys") and hasattr(value, "__getitem__")
+
+def either_dict_or_kwargs(
+    pos_kwargs: typing.Optional[typing.Mapping[str, T]],
+    kw_kwargs: typing.Mapping[str, T],
+    func_name: str,
+) -> typing.Mapping[str, T]:
+    if pos_kwargs is None or pos_kwargs == {}:
+        # Need an explicit cast to appease mypy due to invariance; see
+        # https://github.com/python/mypy/issues/6228
+        return typing.cast(typing.Mapping[str, T], kw_kwargs)
+
+    if not is_dict_like(pos_kwargs):
+        raise ValueError(f"the first argument to .{func_name} must be a dictionary")
+    if kw_kwargs:
+        raise ValueError(
+            f"cannot specify both keyword and positional arguments to .{func_name}"
+        )
+    return pos_kwargs

--- a/ezmsg/util/messagecodec.py
+++ b/ezmsg/util/messagecodec.py
@@ -45,11 +45,11 @@ def import_type(typestr: str) -> type:
 
 class MessageEncoder(json.JSONEncoder):
     def default(self, obj: typing.Any):
-        now = time.time()
         if is_dataclass(obj):
+            ts = getattr(obj, TIMESTAMP_ATTR, time.time())
             return {
-                **{f.name: getattr(obj, f.name) for f in fields(obj)},
-                **{TYPE: type_str(obj), TIMESTAMP_ATTR: now},
+                **{f.name: getattr(obj, f.name) for f in fields(obj)}, 
+                **{TYPE: type_str(obj), TIMESTAMP_ATTR: ts}
             }
 
         elif np and isinstance(obj, np.ndarray):


### PR DESCRIPTION
Running multiple components could result in topic name collisions.  This (unfortunately API-breaking) changeset fixes that, and changes the `ez.run` call signature to require names that don't collide.