### PR TITLE
Update examples to remove deprecated syntax

### DIFF
--- a/examples/ezmsg_count.py
+++ b/examples/ezmsg_count.py
@@ -38,7 +38,7 @@ class Count(ez.Unit):
                 raise ez.Complete
 
 
-class CountSystem(ez.System):
+class CountSystem(ez.Collection):
     COUNT = Count()
     TERM = TerminateTest()
 
@@ -57,8 +57,6 @@ class CountSystem(ez.System):
 
 
 if __name__ == "__main__":
-    # import multiprocessing
-    # multiprocessing.set_start_method('spawn', force=True)
 
     system = CountSystem()
-    ez.run_system(system)
+    ez.run(system)

--- a/examples/ezmsg_normalterm.py
+++ b/examples/ezmsg_normalterm.py
@@ -70,7 +70,7 @@ class ToySystemSettings(ez.Settings):
     output_fn: str
 
 
-class ToySystem(ez.System):
+class ToySystem(ez.Collection):
     SETTINGS: ToySystemSettings
 
     # Publishers
@@ -109,7 +109,7 @@ def main():
     system = ToySystem(
         ToySystemSettings(num_msgs=num_messages, output_fn=test_filename)
     )
-    ez.run_system(system)
+    ez.run(system)
 
     results = []
     with open(test_filename, "r") as file:

--- a/examples/ezmsg_stop.py
+++ b/examples/ezmsg_stop.py
@@ -70,7 +70,7 @@ class ToySystemSettings(ez.Settings):
     output_fn: str
 
 
-class ToySystem(ez.System):
+class ToySystem(ez.Collection):
     SETTINGS: ToySystemSettings
 
     # Publishers
@@ -103,7 +103,7 @@ def main():
     system = ToySystem(
         ToySystemSettings(num_msgs=num_messages, output_fn=test_filename)
     )
-    ez.run_system(system)
+    ez.run(system)
 
     results = []
     with open(test_filename, "r") as file:

--- a/examples/ezmsg_toy.py
+++ b/examples/ezmsg_toy.py
@@ -189,7 +189,7 @@ if __name__ == "__main__":
 
     system = TestSystem(TestSystemSettings(name="A"))
 
-    ez.run_system(
+    ez.run(
         system,
         # name = 'TOY',
         # connections = [


### PR DESCRIPTION
Remove instances of `System` and `run_system()` from the examples directory.