### PR TITLE
Fixes synth.Clock sleep isues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# JetBrains
+.idea/

--- a/extensions/ezmsg-sigproc/ezmsg/sigproc/synth.py
+++ b/extensions/ezmsg-sigproc/ezmsg/sigproc/synth.py
@@ -37,9 +37,13 @@ class Clock(ez.Unit):
 
     @ez.publisher(OUTPUT_CLOCK)
     async def generate(self) -> AsyncGenerator:
+        t_0 = time.time()
+        n_dispatch = 0
         while True:
             if self.STATE.cur_settings.dispatch_rate is not None:
-                await asyncio.sleep(1.0 / self.STATE.cur_settings.dispatch_rate)
+                n_dispatch += 1
+                t_next = t_0 + n_dispatch / self.STATE.cur_settings.dispatch_rate
+                await asyncio.sleep(t_next - time.time())
             yield self.OUTPUT_CLOCK, ez.Flag
 
 


### PR DESCRIPTION
Fixes #41 

With this change, at a nominal rate of 1 kHz, instead of pushing 990 samples/sec I am now pushing around 999.8. My smoothed running average sometimes reports above 1000 but it's usually in the 999.6-999.8 range. I don't know why it isn't bang-on 1000.0 but it could be a precision error in my running average.

I also snuck in an addition to .gitignore