### PR TITLE
zmq - Fixes #49 by making wait for subscribers optional.

### DIFF
--- a/extensions/ezmsg-zmq/ezmsg/zmq/units.py
+++ b/extensions/ezmsg-zmq/ezmsg/zmq/units.py
@@ -45,6 +45,7 @@ class ZMQSenderSettings(ez.Settings):
     write_addr: str
     zmq_topic: str
     multipart: bool = False
+    wait_for_sub: bool = True
 
 
 class ZMQSenderState(ez.State):
@@ -103,7 +104,7 @@ class ZMQSenderUnit(ez.Unit):
 
     @ez.subscriber(INPUT)
     async def zmq_subscriber(self, message: ZMQMessage) -> None:
-        while not self.has_subscribers:
+        while self.SETTINGS.wait_for_sub and not self.has_subscribers:
             await asyncio.sleep(STARTUP_WAIT_TIME)
         if self.SETTINGS.multipart is True:
             await self.STATE.socket.send_multipart(

--- a/extensions/ezmsg-zmq/ezmsg/zmq/units.py
+++ b/extensions/ezmsg-zmq/ezmsg/zmq/units.py
@@ -1,7 +1,6 @@
 import asyncio
 
 from dataclasses import dataclass
-import json
 from pickle import PickleBuffer
 
 import zmq
@@ -107,8 +106,6 @@ class ZMQSenderUnit(ez.Unit):
     async def zmq_subscriber(self, message: ZMQMessage) -> None:
         while self.SETTINGS.wait_for_sub and not self.has_subscribers:
             await asyncio.sleep(STARTUP_WAIT_TIME)
-        if not hasattr(message, "data"):
-            message = ZMQMessage(data=json.dumps(message).encode("utf-8"))
         if self.SETTINGS.multipart is True:
             await self.STATE.socket.send_multipart(
                 (bytes(self.SETTINGS.zmq_topic, "UTF-8"), message.data),

--- a/extensions/ezmsg-zmq/ezmsg/zmq/units.py
+++ b/extensions/ezmsg-zmq/ezmsg/zmq/units.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from dataclasses import dataclass
+import json
 from pickle import PickleBuffer
 
 import zmq
@@ -106,6 +107,8 @@ class ZMQSenderUnit(ez.Unit):
     async def zmq_subscriber(self, message: ZMQMessage) -> None:
         while self.SETTINGS.wait_for_sub and not self.has_subscribers:
             await asyncio.sleep(STARTUP_WAIT_TIME)
+        if not hasattr(message, "data"):
+            message = ZMQMessage(data=json.dumps(message).encode("utf-8"))
         if self.SETTINGS.multipart is True:
             await self.STATE.socket.send_multipart(
                 (bytes(self.SETTINGS.zmq_topic, "UTF-8"), message.data),


### PR DESCRIPTION
See #49 for motivation.
Also added support for json-encodable message-types.