### PR TITLE
Fixes to sigproc.Counter

### DIFF
--- a/extensions/ezmsg-sigproc/ezmsg/sigproc/synth.py
+++ b/extensions/ezmsg-sigproc/ezmsg/sigproc/synth.py
@@ -57,6 +57,8 @@ class CounterSettings(ez.Settings):
     n_ch: int = 1  # Number of channels to synthesize
 
     # Message dispatch rate (Hz), 'realtime', 'ext_clock', or None (fast as possible)
+    #  Note: if dispatch_rate is a float then time offsets will be synthetic and the
+    #  system will run faster or slower than wall clock time.
     dispatch_rate: Optional[Union[float, str]] = None
 
     # If set to an integer, counter will rollover
@@ -65,7 +67,9 @@ class CounterSettings(ez.Settings):
 
 class CounterState(ez.State):
     cur_settings: CounterSettings
-    samp: int = 0  # current sample counter
+    counter_start: int = 0  # next sample's first value
+    clock_zero: float = field(default_factory=time.time)  # time associated with first sample
+    n_sent: int = 0  # It is convenient to know how many samples we have sent.
     clock_event: asyncio.Event
 
 
@@ -82,6 +86,7 @@ class Counter(ez.Unit):
     def initialize(self) -> None:
         self.STATE.clock_event = asyncio.Event()
         self.STATE.clock_event.clear()
+        self.STATE.clock_zero = time.time()
         self.validate_settings(self.SETTINGS)
 
     @ez.subscriber(INPUT_SETTINGS)
@@ -103,38 +108,67 @@ class Counter(ez.Unit):
     @ez.publisher(OUTPUT_SIGNAL)
     async def publish(self) -> AsyncGenerator:
         while True:
-            block_dur = self.STATE.cur_settings.n_time / self.STATE.cur_settings.fs
+            # This generator behaves differently depending on `dispatch_rate`
 
+            # 0. Parse dispatch_rate to get bool flags
+            b_realtime = False
+            b_ext_clock = False
+            b_manual_dispatch = False
             dispatch_rate = self.STATE.cur_settings.dispatch_rate
             if dispatch_rate is not None:
                 if isinstance(dispatch_rate, str):
                     if dispatch_rate == "realtime":
-                        await asyncio.sleep(block_dur)
+                        b_realtime = True
                     elif dispatch_rate == "ext_clock":
-                        await self.STATE.clock_event.wait()
-                        self.STATE.clock_event.clear()
+                        b_ext_clock = True
                 else:
-                    await asyncio.sleep(1.0 / dispatch_rate)
+                    b_manual_dispatch = True
 
+            # 1. Sleep, if necessary, until we are at the end of the current block's data production
+            t_now = time.time()
+            if b_realtime:
+                n_next = self.STATE.n_sent + self.STATE.cur_settings.n_time
+                t_next = self.STATE.clock_zero + n_next / self.STATE.cur_settings.fs
+                await asyncio.sleep(t_next - t_now)
+            elif b_ext_clock:
+                await self.STATE.clock_event.wait()
+                self.STATE.clock_event.clear()
+            elif b_manual_dispatch:
+                n_disp_next = 1 + self.STATE.n_sent / self.STATE.cur_settings.n_time
+                t_disp_next = self.STATE.clock_zero + n_disp_next / dispatch_rate
+                await asyncio.sleep(t_disp_next - t_now)
+                
+            # 2. Prepare counters. Same for all timing methods.
             block_samp = np.arange(self.STATE.cur_settings.n_time)[:, np.newaxis]
-
-            t_samp = block_samp + self.STATE.samp
-            self.STATE.samp = t_samp[-1] + 1
-
+            block_samp += self.STATE.counter_start
             if self.STATE.cur_settings.mod is not None:
-                t_samp %= self.STATE.cur_settings.mod
-                self.STATE.samp %= self.STATE.cur_settings.mod
+                block_samp %= self.STATE.cur_settings.mod
+            block_samp = np.tile(block_samp, (1, self.STATE.cur_settings.n_ch))
 
-            t_samp = np.tile(t_samp, (1, self.STATE.cur_settings.n_ch))
+            # 3. Prepare offset - the time associated with block_samp[0]
+            if b_realtime:
+                offset = t_next - self.STATE.cur_settings.n_time / self.STATE.cur_settings.fs
+            elif b_ext_clock:
+                offset = time.time() - (self.STATE.cur_settings.n_time - 1) / self.STATE.cur_settings.fs
+            else:
+                # Purely synthetic.
+                offset = self.STATE.n_sent / self.STATE.cur_settings.fs
+                # offset += self.STATE.clock_zero  # ??
 
-            offset_adj = self.STATE.cur_settings.n_time / self.STATE.cur_settings.fs
+            # 4. Update state for next iteration
+            self.STATE.counter_start = block_samp[-1, 0] + 1
+            # if self.STATE.cur_settings.mod is not None:
+            #     self.STATE.counter_start is purposely not modded
+            self.STATE.n_sent += self.STATE.cur_settings.n_time
 
+            # 5. Send block
             out = AxisArray(
-                t_samp,
+                block_samp,
                 dims=["time", "ch"],
                 axes=dict(
                     time=AxisArray.Axis.TimeAxis(
-                        fs=self.STATE.cur_settings.fs, offset=time.time() - offset_adj
+                        fs=self.STATE.cur_settings.fs,
+                        offset=offset
                     )
                 ),
             )

--- a/extensions/ezmsg-sigproc/tests/test_synth.py
+++ b/extensions/ezmsg-sigproc/tests/test_synth.py
@@ -1,0 +1,114 @@
+from dataclasses import field
+import os
+from typing import List, Optional, Union
+
+import numpy as np
+import pytest
+
+import ezmsg.core as ez
+from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.messagelogger import MessageLogger, MessageLoggerSettings
+from ezmsg.util.messagecodec import message_log
+from ezmsg.util.terminate import TerminateOnTotalSettings, TerminateOnTotal
+from util import get_test_fn
+from ezmsg.sigproc.synth import Counter, CounterSettings
+
+
+# TEST COUNTER #
+class CounterTestSystemSettings(ez.Settings):
+    counter_settings: CounterSettings
+    log_settings: MessageLoggerSettings
+    term_settings: TerminateOnTotalSettings = field(default_factory=TerminateOnTotalSettings)
+
+
+class CounterTestSystem(ez.Collection):
+    SETTINGS: CounterTestSystemSettings
+
+    COUNTER = Counter()
+    LOG = MessageLogger()
+    TERM = TerminateOnTotal()
+
+    def configure(self) -> None:
+        self.COUNTER.apply_settings(self.SETTINGS.counter_settings)
+        self.LOG.apply_settings(self.SETTINGS.log_settings)
+        self.TERM.apply_settings(self.SETTINGS.term_settings)
+
+    def network(self) -> ez.NetworkDefinition:
+        return (
+            (self.COUNTER.OUTPUT_SIGNAL, self.LOG.INPUT_MESSAGE),
+            (self.LOG.OUTPUT_MESSAGE, self.TERM.INPUT_MESSAGE)
+        )
+
+
+@pytest.mark.parametrize("block_size", [1, 20])
+@pytest.mark.parametrize("fs", [10.0, 1000.0])
+@pytest.mark.parametrize("n_ch", [3])
+@pytest.mark.parametrize("dispatch_rate", [None, "realtime", 2.0, 20.0])  # "ext_clock" needs a separate test
+@pytest.mark.parametrize("mod", [2**3, None])
+def test_counter_system(
+        block_size: int,
+        fs: float,
+        n_ch: int,
+        dispatch_rate: Optional[Union[float, str]],
+        mod: Optional[int],
+        test_name: Optional[str] = None,
+):
+    target_dur = 2.6  # 2.6 seconds per test
+    if dispatch_rate is None:
+        # No sleep / wait
+        chunk_dur = 0.1
+    elif dispatch_rate == "realtime":
+        chunk_dur = block_size / fs
+    else:
+        # Note: float dispatch_rate will yield different number of samples than expected by target_dur and fs
+        chunk_dur = 1. / dispatch_rate
+    target_messages = int(target_dur / chunk_dur)
+
+    test_filename = get_test_fn(test_name)
+    ez.logger.info(test_filename)
+    settings = CounterTestSystemSettings(
+        counter_settings=CounterSettings(
+            n_time=block_size,
+            fs=fs,
+            n_ch=n_ch,
+            dispatch_rate=dispatch_rate,
+            mod=mod,
+        ),
+        log_settings=MessageLoggerSettings(
+            output=test_filename,
+        ),
+        term_settings=TerminateOnTotalSettings(
+            total=target_messages,
+        )
+    )
+    system = CounterTestSystem(settings)
+    ez.run(SYSTEM=system)
+
+    # Collect result
+    messages: List[AxisArray] = [_ for _ in message_log(test_filename)]
+    os.remove(test_filename)
+
+    if dispatch_rate is None:
+        # The number of messages depends on how fast the computer is
+        target_messages = len(messages)
+    assert len(messages) == target_messages
+
+    target_samples = block_size * target_messages
+    time_idx, ch_idx = messages[0].get_axis_idx("time"), messages[0].get_axis_idx("ch")
+    data = np.concatenate([_.data for _ in messages], axis=time_idx)
+    assert data.shape[0] == target_samples
+    assert data.shape[ch_idx] == n_ch
+    expected_data = np.arange(target_samples)
+    if mod is not None:
+        expected_data = expected_data % mod
+    assert np.array_equal(data[:, 0], expected_data)
+
+    offsets = np.array([_.axes["time"].offset for _ in messages])
+    expected_offsets = np.arange(target_messages) * block_size / fs
+    if dispatch_rate is not None and dispatch_rate == "realtime":
+        expected_offsets += offsets[0]  # offsets are in real-time
+        atol = 0.002
+    else:
+        # Offsets are synthetic.
+        atol = 1.e-8
+    assert np.allclose(offsets[2:], expected_offsets[2:], atol=atol)


### PR DESCRIPTION
This PR adds a new set of tests for sigproc.Counter. The tests are pretty thorough and test the generated time axis .offset values as well as the counter values themselves.

In the same commit I modified Counter to sastisfy the unit tests. This required a near total rewrite of the `publish` method.

I tried for hours to satisfy the unit tests with `dispatch_rate="realtime"` without using a state variables to keep track of counters and time-since start. I also tried resetting those variables to avoid precision errors as the numbers get very large. In the end, I couldn't succeed, and I left the variables as resetting on startup but never resetting as progress continues.