### PR TITLE
Fixes to sigproc.Window

### DIFF
--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/window.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/window.py
@@ -1,12 +1,190 @@
 from dataclasses import replace
+from typing import AsyncGenerator, Optional, Tuple, List, Generator, Union
 
 import ezmsg.core as ez
 import numpy as np
 import numpy.typing as npt
+import numpy.lib.stride_tricks as nps
 
-from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.messages.axisarray import AxisArray, slice_along_axis, sliding_win_oneaxis
+from ezmsg.util.generator import consumer
 
-from typing import AsyncGenerator, Optional, Tuple, List
+
+@consumer
+def window(
+        axis: Optional[str] = None,
+        newaxis: Optional[str] = None,
+        window_dur: Optional[float] = None,
+        window_shift: Optional[float] = None,
+        zero_pad_until: str = "input"
+) -> Generator[AxisArray, List[AxisArray], None]:
+    """
+    Window function that generates windows of data from an input `AxisArray`.
+
+    :param axis: (Optional[str]): The axis along which to segment windows.
+        If None, defaults to the first dimension of the first seen AxisArray.
+    :param newaxis (Optional[str]): Optional new axis for the output. If None, no new axes will be added.
+        If a string, windows will be stacked in a new axis with key `newaxis`, immediately preceding the windowed axis.
+    :param window_dur (Optional[float]): The duration of the window in seconds.
+        If None, the function acts as a passthrough and all other parameters are ignored.
+    :param window_shift (Optional[float]): The shift of the window in seconds.
+        If None (default), windowing operates in "1:1 mode", where each input yields exactly one most-recent window.
+    :param zero_pad_until (str): Determines how the function initializes the buffer.
+        Can be one of "input" (default), "full", "shift", or "none". If `window_shift` is None then this field is
+        ignored and "input" is always used.
+        "input" (default) initializes the buffer with the input then prepends with zeros to the window size.
+            The first input will always yield at least one output.
+        "shift" fills the buffer until `window_shift`.
+            No outputs will be yielded until at least `window_shift` data has been seen.
+        "none" does not pad the buffer. No outputs will be yielded until at least `window_dur` data has been seen.
+    :return:
+        A (primed) generator that accepts .send(an AxisArray object) and yields a list of windowed
+        AxisArray objects. The list will always be length-1 if `newaxis` is not None or `window_shift` is None.
+
+    """
+    if window_shift is None and zero_pad_until != "input":
+        ez.logger.warning("`zero_pad_until` must be 'input' if `window_shift` is None. "
+                          f"Ignoring received argument value: {zero_pad_until}")
+        zero_pad_until = "input"
+    elif window_shift is not None and zero_pad_until == "input":
+        ez.logger.warning("windowing is non-deterministic with `zero_pad_until='input'` as it depends on the size "
+                          "of the first input. We recommend using 'shift' when `window_shift` is float-valued.")
+    axis_arr_in = AxisArray(np.array([]), dims=[""])
+    axis_arr_out = [AxisArray(np.array([]), dims=[""])]
+
+    # State variables
+    prev_samp_shape: Optional[Tuple[int, ...]] = None
+    prev_fs: Optional[float] = None
+    buffer: Optional[npt.NDArray] = None
+    window_samples: Optional[int] = None
+    window_shift_samples: Optional[int] = None
+    shift_deficit: int = 0  # Number of incoming samples to ignore. Only relevant when shift > window.
+    newaxis_warn_flag: bool = False
+    mod_ax: Optional[str] = None  # The key of the modified axis in the output's .axes
+    out_template: Optional[AxisArray] = None  # Template for building return values.
+
+    while True:
+        axis_arr_in = yield axis_arr_out
+
+        if axis is None:
+            axis = axis_arr_in.dims[0]
+        axis_idx = axis_arr_in.get_axis_idx(axis)
+        axis_info = axis_arr_in.get_axis(axis)
+        fs = 1.0 / axis_info.gain
+
+        if (not newaxis_warn_flag) and newaxis is not None and newaxis in axis_arr_in.dims:
+            ez.logger.warning(f"newaxis {newaxis} present in input dims and will be ignored.")
+            newaxis_warn_flag = True
+        b_newaxis = newaxis is not None and newaxis not in axis_arr_in.dims
+
+        samp_shape = axis_arr_in.data.shape[:axis_idx] + axis_arr_in.data.shape[axis_idx + 1:]
+        window_samples = int(window_dur * fs)
+        b_1to1 = window_shift is None
+        if not b_1to1:
+            window_shift_samples = int(window_shift * fs)
+
+        # If buffer unset or input stats changed, create a new buffer
+        if buffer is None or samp_shape != prev_samp_shape or fs != prev_fs:
+            if zero_pad_until == "none":
+                req_samples = window_samples
+            elif zero_pad_until == "shift" and not b_1to1:
+                req_samples = window_shift_samples
+            else:  # i.e. zero_pad_until == "input"
+                req_samples = axis_arr_in.data.shape[axis_idx]
+            n_zero = max(0, window_samples - req_samples)
+            buffer_shape = axis_arr_in.data.shape[:axis_idx] + (n_zero,) + axis_arr_in.data.shape[axis_idx + 1:]
+            buffer = np.zeros(buffer_shape)
+            ndims_tail = buffer.ndim - axis_idx - 1
+            prev_samp_shape = samp_shape
+            prev_fs = fs
+
+        # Add new data to buffer.
+        # Currently we just concatenate the new time samples and clip the output
+        # np.roll actually returns a copy, and there's no way to construct a
+        # rolling view of the data.  In current numpy implementations, np.concatenate
+        # is generally faster than np.roll and slicing anyway, but this could still
+        # be a performance bottleneck for large memory arrays.
+        buffer = np.concatenate((buffer, axis_arr_in.data), axis=axis_idx)
+        # Note: if we ever move to using a circular buffer without copies then we need to create copies somewhere,
+        #  because currently the outputs are merely views into the buffer.
+
+        # Create a vector of buffer timestamps to track axis `offset` in output(s)
+        buffer_offset = np.arange(buffer.shape[axis_idx]).astype(float)
+        # Adjust so first _new_ sample at index 0
+        buffer_offset -= buffer_offset[-axis_arr_in.data.shape[axis_idx]]
+        # Convert form indices to 'units' (probably seconds).
+        buffer_offset *= axis_info.gain
+        buffer_offset += axis_info.offset
+
+        if not b_1to1 and shift_deficit > 0:
+            n_skip = min(buffer.shape[axis_idx], shift_deficit)
+            if n_skip > 0:
+                buffer = slice_along_axis(buffer, np.s_[n_skip:], axis_idx)
+                buffer_offset = buffer_offset[n_skip:]
+                shift_deficit -= n_skip
+
+        # Prepare reusable parts of output
+        if out_template is None:
+            out_dims = axis_arr_in.dims
+            if newaxis is None:
+                out_axes = {
+                    **axis_arr_in.axes,
+                    axis: replace(axis_info, offset=0.0)  # offset modified below.
+                }
+                mod_ax = axis
+            else:
+                out_dims = out_dims[:axis_idx] + [newaxis] + out_dims[axis_idx:]
+                out_axes = {
+                    **axis_arr_in.axes,
+                    newaxis: AxisArray.Axis(
+                        unit=axis_info.unit,
+                        gain=0.0 if b_1to1 else axis_info.gain * window_shift_samples,
+                        offset=0.0  # offset modified below
+                    )
+                }
+                mod_ax = newaxis
+            out_template = replace(axis_arr_in, data=np.zeros([0 for _ in out_dims]), dims=out_dims)
+
+        # Generate outputs.
+        axis_arr_out: List[AxisArray] = []
+        if b_1to1:
+            # one-to-one mode -- Each send yields exactly one window containing only the most recent samples.
+            buffer = slice_along_axis(buffer, np.s_[-window_samples:], axis_idx)
+            axis_arr_out.append(replace(
+                    out_template,
+                    data=np.expand_dims(buffer, axis=axis_idx) if b_newaxis else buffer,
+                    axes={
+                        **out_axes,
+                        mod_ax: replace(out_axes[mod_ax], offset=buffer_offset[-window_samples])
+                    }
+            ))
+        elif buffer.shape[axis_idx] >= window_samples:
+            # Deterministic window shifts.
+            win_view = sliding_win_oneaxis(buffer, window_samples, axis_idx)
+            win_view = slice_along_axis(win_view, np.s_[::window_shift_samples], axis_idx)
+            offset_view = sliding_win_oneaxis(buffer_offset, window_samples, 0)[::window_shift_samples]
+            # Place in output
+            if b_newaxis:
+                axis_arr_out.append(replace(
+                    out_template,
+                    data=win_view,
+                    axes={**out_axes, mod_ax: replace(out_axes[mod_ax], offset=offset_view[0, 0])}
+                ))
+            else:
+                for win_ix in range(win_view.shape[axis_idx]):
+                    axis_arr_out.append(replace(
+                        out_template,
+                        data=slice_along_axis(win_view, win_ix, axis_idx),
+                        axes={
+                            **out_axes,
+                            mod_ax: replace(out_axes[mod_ax], offset=offset_view[win_ix, 0])
+                        }
+                    ))
+
+            # Drop expired beginning of buffer and update shift_deficit
+            multi_shift = window_shift_samples * win_view.shape[axis_idx]
+            shift_deficit = max(0, multi_shift - buffer.shape[axis_idx])
+            buffer = slice_along_axis(buffer, np.s_[multi_shift:], axis_idx)
 
 
 class WindowSettings(ez.Settings):
@@ -23,12 +201,7 @@ class WindowSettings(ez.Settings):
 
 class WindowState(ez.State):
     cur_settings: WindowSettings
-
-    samp_shape: Optional[Tuple[int, ...]] = None  # Shape of individual sample
-    out_fs: Optional[float] = None
-    buffer: Optional[npt.NDArray] = None
-    window_samples: Optional[int] = None
-    window_shift_samples: Optional[int] = None
+    gen: Generator
 
 
 class Window(ez.Unit):
@@ -41,11 +214,24 @@ class Window(ez.Unit):
 
     def initialize(self) -> None:
         self.STATE.cur_settings = self.SETTINGS
+        self.STATE.gen = window(
+            axis=self.STATE.cur_settings.axis,
+            newaxis=self.STATE.cur_settings.newaxis,
+            window_dur=self.STATE.cur_settings.window_dur,
+            window_shift=self.STATE.cur_settings.window_shift,
+            zero_pad_until=self.STATE.cur_settings.zero_pad_until
+        )
 
     @ez.subscriber(INPUT_SETTINGS)
     async def on_settings(self, msg: WindowSettings) -> None:
         self.STATE.cur_settings = msg
-        self.STATE.out_fs = None  # This should trigger a reallocation
+        self.STATE.gen = window(
+            axis=self.STATE.cur_settings.axis,
+            newaxis=self.STATE.cur_settings.newaxis,
+            window_dur=self.STATE.cur_settings.window_dur,
+            window_shift=self.STATE.cur_settings.window_shift,
+            zero_pad_until=self.STATE.cur_settings.zero_pad_until
+        )
 
     @ez.subscriber(INPUT_SIGNAL)
     @ez.publisher(OUTPUT_SIGNAL)
@@ -54,94 +240,11 @@ class Window(ez.Unit):
             yield self.OUTPUT_SIGNAL, msg
             return
 
-        axis_name = self.STATE.cur_settings.axis
-        if axis_name is None:
-            axis_name = msg.dims[0]
-        axis_idx = msg.get_axis_idx(axis_name)
-        axis = msg.get_axis(axis_name)
-        fs = 1.0 / axis.gain
-
-        # Create a view of data with time axis at dim 0
-        time_view = np.moveaxis(msg.data, axis_idx, 0)
-        samp_shape = time_view.shape[1:]
-
-        self.STATE.window_samples = int(self.STATE.cur_settings.window_dur * fs)
-        self.STATE.samp_shape = samp_shape
-        self.STATE.out_fs = fs
-
-        self.STATE.window_shift_samples = None
-        if self.STATE.cur_settings.window_shift is not None:
-            self.STATE.window_shift_samples = int(
-                fs * self.STATE.cur_settings.window_shift
-            )
-
-        # Prepare zero-padding in buffer
-        if (
-                (self.STATE.samp_shape != samp_shape)
-                or (self.STATE.out_fs != fs)
-                or self.STATE.buffer is None
-        ):
-            zp_flag = self.STATE.cur_settings.zero_pad_until
-            if zp_flag == "shift" and self.STATE.window_shift_samples is not None:
-                n_zero = self.STATE.window_samples - self.STATE.window_shift_samples
-            elif zp_flag == "input":
-                n_zero = self.STATE.window_samples - time_view.shape[0]
-            elif zp_flag == "none":
-                n_zero = 0
-            else:  # zp_flag == "full":
-                n_zero = self.STATE.window_samples
-            n_zero = max(0, n_zero)
-            self.STATE.buffer = np.zeros(tuple([n_zero] + list(samp_shape)))
-
-        # Currently we just concatenate the new time samples and clip the output
-        # np.roll actually returns a copy, and there's no way to construct a
-        # rolling view of the data.  In current numpy implementations, np.concatenate
-        # is generally faster than np.roll and slicing anyway, but this could still
-        # be a performance bottleneck for large memory arrays.
-        self.STATE.buffer = np.concatenate((self.STATE.buffer, time_view), axis=0)
-
-        buffer_offset = np.arange(self.STATE.buffer.shape[0])
-        buffer_offset -= buffer_offset[-time_view.shape[0]]  # Adjust so first new sample = 0
-        buffer_offset = (buffer_offset * axis.gain) + axis.offset
-
-        outputs: List[Tuple[npt.NDArray, float]] = []
-
-        if self.STATE.window_shift_samples is None:  # one-to-one mode
-            self.STATE.buffer = self.STATE.buffer[-self.STATE.window_samples :, ...]
-            buffer_offset = buffer_offset[-self.STATE.window_samples :]
-            outputs.append((self.STATE.buffer, buffer_offset[0]))
-
-        else:
-            yieldable_size = self.STATE.window_samples + self.STATE.window_shift_samples
-            while self.STATE.buffer.shape[0] >= yieldable_size:
-                outputs.append((
-                    self.STATE.buffer[: self.STATE.window_samples, ...],
-                    buffer_offset[0],
-                ))
-                self.STATE.buffer = self.STATE.buffer[
-                    self.STATE.window_shift_samples :, ...
-                ]
-                buffer_offset = buffer_offset[self.STATE.window_shift_samples :]
-
-        for out_view, offset in outputs:
-            out_view = np.moveaxis(out_view, 0, axis_idx)
-            out_dims = msg.dims
-            out_axes = msg.axes.copy()  # Copy because `replace` doesn't seem to make a copy of dict fields.
-            if axis_name in msg.axes:
-                out_axes[axis_name] = replace(out_axes[axis_name], offset=offset)
-
-            if (
-                self.STATE.cur_settings.newaxis is not None
-                and self.STATE.cur_settings.newaxis != self.STATE.cur_settings.axis
-            ):
-                out_view = out_view[np.newaxis, ...]
-                out_dims = [self.STATE.cur_settings.newaxis] + msg.dims
-
-                new_gain = 0.0
-                if self.STATE.window_shift_samples is not None:
-                    new_gain = axis.gain * self.STATE.window_shift_samples
-                new_axis = AxisArray.Axis(unit=axis.unit, gain=new_gain, offset=offset)
-                out_axes = {**msg.axes, **{self.STATE.cur_settings.newaxis: new_axis}}
-
-            result = replace(msg, data=out_view, dims=out_dims, axes=out_axes)
-            yield self.OUTPUT_SIGNAL, result
+        try:
+            out_msgs = self.STATE.gen.send(msg)
+            for out_msg in out_msgs:
+                yield self.OUTPUT_SIGNAL, out_msg
+        except (StopIteration, GeneratorExit):
+            ez.logger.debug(f"Window closed in {self.address}")
+        except Exception:
+            ez.logger.info(traceback.format_exc())

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/window.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/window.py
@@ -189,13 +189,9 @@ def window(
 
 class WindowSettings(ez.Settings):
     axis: Optional[str] = None
-    newaxis: Optional[
-        str
-    ] = None  # Optional new axis for output.  If "None" - no new axes on output
-    window_dur: Optional[
-        float
-    ] = None  # Sec.  If "None" -- passthrough; window_shift is ignored.
-    window_shift: Optional[float] = None  # Sec.  If "None", activate "1:1 mode"
+    newaxis: Optional[str] = None  # new axis for output. No new axes if None
+    window_dur: Optional[float] = None  # Sec. passthrough if None
+    window_shift: Optional[float] = None  # Sec. Use "1:1 mode" if None
     zero_pad_until: str = "full"  # "full", "shift", "input", "none"
 
 
@@ -214,17 +210,14 @@ class Window(ez.Unit):
 
     def initialize(self) -> None:
         self.STATE.cur_settings = self.SETTINGS
-        self.STATE.gen = window(
-            axis=self.STATE.cur_settings.axis,
-            newaxis=self.STATE.cur_settings.newaxis,
-            window_dur=self.STATE.cur_settings.window_dur,
-            window_shift=self.STATE.cur_settings.window_shift,
-            zero_pad_until=self.STATE.cur_settings.zero_pad_until
-        )
+        self.construct_generator()
 
     @ez.subscriber(INPUT_SETTINGS)
     async def on_settings(self, msg: WindowSettings) -> None:
         self.STATE.cur_settings = msg
+        self.construct_generator()
+
+    def construct_generator(self):
         self.STATE.gen = window(
             axis=self.STATE.cur_settings.axis,
             newaxis=self.STATE.cur_settings.newaxis,

--- a/extensions/ezmsg-sigproc/tests/test_window.py
+++ b/extensions/ezmsg-sigproc/tests/test_window.py
@@ -5,6 +5,7 @@ import json
 
 import pytest
 import numpy as np
+from numpy.lib.stride_tricks import sliding_window_view
 import ezmsg.core as ez
 
 from ezmsg.util.messages.axisarray import AxisArray
@@ -19,7 +20,7 @@ from ezmsg.util.terminate import TerminateOnTimeout as TerminateTest
 from ezmsg.util.terminate import TerminateOnTimeoutSettings as TerminateTestSettings
 from ezmsg.util.debuglog import DebugLog
 
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 
 
 class WindowSystemSettings(ez.Settings):
@@ -68,16 +69,23 @@ class WindowSystem(ez.Collection):
 
 
 @pytest.mark.parametrize("block_size", [1, 5, 10, 20])
+@pytest.mark.parametrize("newaxis", [None, "step"])
 @pytest.mark.parametrize("win_dur", [0.2, 1.0])
 @pytest.mark.parametrize("win_shift", [None, 0.1, 1.0])
 def test_window_system(
     block_size: int,
+    newaxis: Optional[str],
     win_dur: float,
     win_shift: Optional[float],
     test_name: Optional[str] = None,
 ):
     in_fs = 10.0  # Hz
-    num_msgs = int((in_fs / block_size) * 4.0)  # Ensure 4 seconds of data
+    zero_pad_until = "full"  # See WindowSettings for other options
+    # Calculate expected dimensions.
+    win_len = int(win_dur * in_fs)
+    shift_len = int(win_shift * in_fs) if win_shift is not None else block_size
+    # num_msgs should be the greater value between (2 full windows + a shift) or 4.0 seconds
+    num_msgs = int(np.ceil(max(2 * win_len + shift_len - 1, 4.0 * in_fs) / block_size))
 
     test_filename = get_test_fn(test_name)
     ez.logger.info(test_filename)
@@ -85,52 +93,79 @@ def test_window_system(
     settings = WindowSystemSettings(
         num_msgs=num_msgs,
         counter_settings=CounterSettings(
-            n_time=block_size, fs=in_fs, dispatch_rate=20.0
+            n_time=block_size,
+            fs=in_fs,
+            dispatch_rate=float(num_msgs),  # Get through them in about 1 second.
         ),
-        window_settings=WindowSettings(window_dur=win_dur, window_shift=win_shift),
+        window_settings=WindowSettings(
+            axis=None,
+            newaxis=newaxis,
+            window_dur=win_dur,
+            window_shift=win_shift,
+            zero_pad_until=zero_pad_until
+        ),
         log_settings=MessageLoggerSettings(output=test_filename),
         term_settings=TerminateTestSettings(time=1.0),  # sec
     )
 
     system = WindowSystem(settings)
+    ez.run(SYSTEM=system)
 
-    ez.run(SYSTEM = system)
-
-    messages: List[AxisArray] = []
-    for msg in message_log(test_filename):
-        messages.append(msg)
-
+    messages: List[AxisArray] = [_ for _ in message_log(test_filename)]
     os.remove(test_filename)
-
     ez.logger.info(f"Analyzing recording of { len( messages ) } messages...")
 
-    fs: Optional[float] = None
-    dims: Optional[List[str]] = None
-    data: List[np.ndarray] = []
+    # Within a test config, the metadata should not change across messages.
+    dims: List[str] = messages[0].dims
+    n_ch = messages[0].shape[messages[0].get_axis_idx("ch")]
     for msg in messages:
         # In this test, fs should never change
-        msg_fs = 1.0 / msg.axes["time"].gain
-        if fs is None:
-            fs = msg_fs
-        assert fs == msg_fs
-
+        assert 1.0 / msg.axes["time"].gain == in_fs
         # In this test, we should have consistent dimensions
-        if dims is None:
-            dims = msg.dims
-        else:
-            assert dims == msg.dims
-
-        data.append(msg.data)
-
+        assert dims == msg.dims
         # Window should always output the same shape data
-        assert data[0].shape == msg.shape
+        assert msg.shape[msg.get_axis_idx("ch")] == n_ch
+        assert msg.shape[msg.get_axis_idx("time")] == win_len
 
     ez.logger.info("Consistent metadata!")
+
+    # Collect the outputs we want to test
+    data: List[np.ndarray] = [msg.data for msg in messages]
+    offsets: np.ndarray = np.array([msg.axes[newaxis or "time"].offset for msg in messages])
 
     # If this test was performed in "one-to-one" mode, we should
     # have one window output per message pushed to Window
     if win_shift is None:
         assert len(data) == num_msgs
+
+    # Turn the data into a ndarray.
+    concat_ax = 0
+    if newaxis is not None:
+        concat_ax = messages[0].get_axis_idx(newaxis)
+        data = np.concatenate(data, axis=concat_ax)
+    else:
+        data = np.stack(data)
+
+    # We need to calculate how much zero padding there was so we know what to expect in the output.
+    if zero_pad_until == "input":
+        # As we are using zero_pad_until = "input", our padding is win_len - block_size
+        zero_pad = max(0, win_len - block_size)
+    else:  # "full"
+        zero_pad = win_len
+
+    # Check data
+    assert data.shape[concat_ax] == len(messages)
+    expected_counts = np.arange(num_msgs * block_size + zero_pad).astype(float) - zero_pad
+    expected_data = sliding_window_view(expected_counts, (win_len,))
+    if win_shift is None:
+        expected_data = expected_data[max(0, block_size - win_len)::block_size]
+    else:
+        expected_data = expected_data[::shift_len][:data.shape[concat_ax]]
+    assert np.array_equal(data, np.clip(expected_data[..., None], 0, None))
+
+    # Check offsets
+    expected_offsets = expected_data[:, 0] / in_fs
+    assert np.allclose(offsets, expected_offsets)
 
     ez.logger.info("Test Complete.")
 

--- a/extensions/ezmsg-sigproc/tests/test_window.py
+++ b/extensions/ezmsg-sigproc/tests/test_window.py
@@ -1,4 +1,4 @@
-from dataclasses import field
+from dataclasses import field, replace
 
 import os
 import json
@@ -13,7 +13,7 @@ from ezmsg.util.messagegate import MessageGate, MessageGateSettings
 from ezmsg.util.messagelogger import MessageLogger, MessageLoggerSettings
 from ezmsg.util.messagecodec import message_log
 from ezmsg.sigproc.synth import Counter, CounterSettings
-from ezmsg.sigproc.window import Window, WindowSettings
+from ezmsg.sigproc.window import Window, WindowSettings, window
 
 from util import get_test_fn
 from ezmsg.util.terminate import TerminateOnTimeout as TerminateTest
@@ -21,6 +21,129 @@ from ezmsg.util.terminate import TerminateOnTimeoutSettings as TerminateTestSett
 from ezmsg.util.debuglog import DebugLog
 
 from typing import Optional, Dict, Any, List, Tuple
+
+
+def calculate_expected_results(orig, fs, win_shift, zero_pad, msg_block_size, shift_len, win_len, nchans, data_len, n_msgs, win_ax):
+    # For the calculation, we assume time_ax is last then transpose if necessary at the end.
+    expected = orig.copy()
+    tvec = np.arange(orig.shape[1]) / fs
+    # Prepend the data with zero-padding, if necessary.
+    if win_shift is None or zero_pad == "input":
+        n_cut = msg_block_size
+    elif zero_pad == "shift":
+        n_cut = shift_len
+    else:  # "none" -- no buffer needed
+        n_cut = win_len
+    n_keep = win_len - n_cut
+    if n_keep > 0:
+        expected = np.concatenate((np.zeros((nchans, win_len))[..., -n_keep:], expected), axis=-1)
+        tvec = np.hstack(((np.arange(-win_len, 0) / fs)[-n_keep:], tvec))
+    # Moving window -- assumes step size of 1
+    expected = sliding_window_view(expected, win_len, axis=-1)
+    tvec = sliding_window_view(tvec, win_len)
+    # Mimic win_shift
+    if win_shift is None:
+        # 1:1 mode. Each input (block) yields a new output.
+        # If the window length is smaller than the block size then we only the tail of each block.
+        first = max(min(msg_block_size, data_len) - win_len, 0)
+        if tvec[::msg_block_size].shape[0] < n_msgs:
+            expected = np.concatenate((expected[:, first::msg_block_size], expected[:, -1:]), axis=1)
+            tvec = np.hstack((tvec[first::msg_block_size, 0], tvec[-1:, 0]))
+        else:
+            expected = expected[:, first::msg_block_size]
+            tvec = tvec[first::msg_block_size, 0]
+    else:
+        expected = expected[:, ::shift_len]
+        tvec = tvec[::shift_len, 0]
+    # Transpose to put time_ax and win_ax in the correct locations.
+    if win_ax == 0:
+        expected = np.moveaxis(expected, 0, -1)
+
+    return expected, tvec
+
+
+@pytest.mark.parametrize("msg_block_size", [1, 5, 10, 20, 60])
+@pytest.mark.parametrize("newaxis", [None, "win"])
+@pytest.mark.parametrize("win_dur", [0.2, 1.0])
+@pytest.mark.parametrize("win_shift", [None, 0.1, 1.0])
+@pytest.mark.parametrize("zero_pad", ["input", "shift", "none"])
+@pytest.mark.parametrize("fs", [10.0, 500.0])
+@pytest.mark.parametrize("time_ax", [0, 1])
+def test_window_generator(
+        msg_block_size: int,
+        newaxis: Optional[str],
+        win_dur: float,
+        win_shift: Optional[float],
+        zero_pad: str,
+        fs: float,
+        time_ax: int
+):
+    nchans = 3
+
+    shift_len = int(win_shift * fs) if win_shift is not None else None
+    win_len = int(win_dur * fs)
+    data_len = 2 * win_len
+    if win_shift is not None:
+        data_len += shift_len - 1
+    data = np.arange(nchans * data_len, dtype=float).reshape((nchans, data_len))
+    # Below, we transpose the individual messages if time_ax == 0.
+    tvec = np.arange(data_len) / fs
+
+    n_msgs = int(np.ceil(data_len / msg_block_size))
+
+    # Instantiate the generator function
+    gen = window(axis="time", newaxis=newaxis, window_dur=win_dur, window_shift=win_shift, zero_pad_until=zero_pad)
+
+    # Create inputs and send them to the generator, collecting the results along the way.
+    test_msg = AxisArray(
+        data[..., ()],
+        dims=["ch", "time"] if time_ax == 1 else ["time", "ch"],
+        axes={"time": AxisArray.Axis.TimeAxis(fs=fs, offset=0.)}
+    )
+    results = []
+    for msg_ix in range(n_msgs):
+        msg_data = data[..., msg_ix * msg_block_size:(msg_ix+1) * msg_block_size]
+        if time_ax == 0:
+            msg_data = np.ascontiguousarray(msg_data.T)
+        test_msg = replace(test_msg, data=msg_data, axes={
+            "time": AxisArray.Axis.TimeAxis(fs=fs, offset=tvec[msg_ix * msg_block_size])
+        })
+        wins = gen.send(test_msg)
+        results.extend(wins)
+
+    # Check each return value's metadata (offsets checked at end)
+    for msg in results:
+        assert msg.axes["time"].gain == 1/fs
+        if newaxis is None:
+            assert msg.dims == test_msg.dims
+        else:
+            assert msg.dims == test_msg.dims[:time_ax] + [newaxis] + test_msg.dims[time_ax:]
+            assert newaxis in msg.axes
+            assert msg.axes[newaxis].gain == 0.0 if win_shift is None else shift_len / fs
+
+    # Post-process the results to yield a single data array and a single vector of offsets.
+    win_ax = time_ax
+    if newaxis is None:
+        result = np.stack([_.data for _ in results], axis=time_ax)
+        # np.stack creates new axis before target axis.
+        time_ax += 1
+        offsets = np.array([_.axes["time"].offset for _ in results])
+    else:
+        # win_ax already in data; replaced time_ax, time_ax moved to end.
+        result = np.concatenate([_.data for _ in results], axis=win_ax)
+        time_ax = result.ndim - 1
+        offsets = np.hstack([
+            _.axes[newaxis].offset + _.axes[newaxis].gain * np.arange(_.data.shape[win_ax])
+            for _ in results
+        ])
+
+    # Calculate the expected results for comparison.
+    expected, tvec = calculate_expected_results(data, fs, win_shift, zero_pad, msg_block_size, shift_len, win_len,
+                                                nchans, data_len, n_msgs, win_ax)
+
+    # Compare results to expected
+    assert np.array_equal(result, expected)
+    assert np.allclose(offsets, tvec)
 
 
 class WindowSystemSettings(ez.Settings):
@@ -68,24 +191,31 @@ class WindowSystem(ez.Collection):
         )
 
 
-@pytest.mark.parametrize("block_size", [1, 5, 10, 20])
-@pytest.mark.parametrize("newaxis", [None, "step"])
-@pytest.mark.parametrize("win_dur", [0.2, 1.0])
-@pytest.mark.parametrize("win_shift", [None, 0.1, 1.0])
+# It takes >15 minutes to go through the full set of combinations tested for the generator.
+# We need only test a subset to assert integration is correct.
+@pytest.mark.parametrize("msg_block_size, newaxis, win_dur, win_shift, zero_pad, fs", [
+    (1, None, 0.2, None, "input", 10.0),
+    (20, None, 0.2, None, "input", 10.0),
+    (1, "step", 0.2, None, "input", 10.0),
+    (10, "step", 0.2, 1.0, "shift", 500.0),
+    (20, "step", 1.0, 1.0, "shift", 500.0),
+    (10, "step", 1.0, 1.0, "none", 500.0),
+])
 def test_window_system(
-    block_size: int,
+    msg_block_size: int,
     newaxis: Optional[str],
     win_dur: float,
     win_shift: Optional[float],
+    zero_pad: str,
+    fs: float,
     test_name: Optional[str] = None,
 ):
-    in_fs = 10.0  # Hz
-    zero_pad_until = "full"  # See WindowSettings for other options
     # Calculate expected dimensions.
-    win_len = int(win_dur * in_fs)
-    shift_len = int(win_shift * in_fs) if win_shift is not None else block_size
+    win_len = int(win_dur * fs)
+    shift_len = int(win_shift * fs) if win_shift is not None else msg_block_size
     # num_msgs should be the greater value between (2 full windows + a shift) or 4.0 seconds
-    num_msgs = int(np.ceil(max(2 * win_len + shift_len - 1, 4.0 * in_fs) / block_size))
+    data_len = max(2 * win_len + shift_len - 1, int(4.0 * fs))
+    num_msgs = int(np.ceil(data_len / msg_block_size))
 
     test_filename = get_test_fn(test_name)
     ez.logger.info(test_filename)
@@ -93,16 +223,16 @@ def test_window_system(
     settings = WindowSystemSettings(
         num_msgs=num_msgs,
         counter_settings=CounterSettings(
-            n_time=block_size,
-            fs=in_fs,
+            n_time=msg_block_size,
+            fs=fs,
             dispatch_rate=float(num_msgs),  # Get through them in about 1 second.
         ),
         window_settings=WindowSettings(
-            axis=None,
+            axis="time",
             newaxis=newaxis,
             window_dur=win_dur,
             window_shift=win_shift,
-            zero_pad_until=zero_pad_until
+            zero_pad_until=zero_pad
         ),
         log_settings=MessageLoggerSettings(output=test_filename),
         term_settings=TerminateTestSettings(time=1.0),  # sec
@@ -116,22 +246,26 @@ def test_window_system(
     ez.logger.info(f"Analyzing recording of { len( messages ) } messages...")
 
     # Within a test config, the metadata should not change across messages.
-    dims: List[str] = messages[0].dims
-    n_ch = messages[0].shape[messages[0].get_axis_idx("ch")]
     for msg in messages:
         # In this test, fs should never change
-        assert 1.0 / msg.axes["time"].gain == in_fs
+        assert 1.0 / msg.axes["time"].gain == fs
         # In this test, we should have consistent dimensions
-        assert dims == msg.dims
+        assert msg.dims == [newaxis, "time", "ch"] if newaxis else ["time", "ch"]
         # Window should always output the same shape data
-        assert msg.shape[msg.get_axis_idx("ch")] == n_ch
+        assert msg.shape[msg.get_axis_idx("ch")] == 1  # Counter yields only one channel.
         assert msg.shape[msg.get_axis_idx("time")] == win_len
 
     ez.logger.info("Consistent metadata!")
 
     # Collect the outputs we want to test
     data: List[np.ndarray] = [msg.data for msg in messages]
-    offsets: np.ndarray = np.array([msg.axes[newaxis or "time"].offset for msg in messages])
+    if newaxis is None:
+        offsets = np.array([_.axes["time"].offset for _ in messages])
+    else:
+        offsets = np.hstack([
+            _.axes[newaxis].offset + _.axes[newaxis].gain * np.arange(_.data.shape[0])
+            for _ in messages
+        ])
 
     # If this test was performed in "one-to-one" mode, we should
     # have one window output per message pushed to Window
@@ -139,33 +273,19 @@ def test_window_system(
         assert len(data) == num_msgs
 
     # Turn the data into a ndarray.
-    concat_ax = 0
     if newaxis is not None:
-        concat_ax = messages[0].get_axis_idx(newaxis)
-        data = np.concatenate(data, axis=concat_ax)
+        data = np.concatenate(data, axis=messages[0].get_axis_idx(newaxis))
     else:
-        data = np.stack(data)
+        data = np.stack(data, axis=messages[0].get_axis_idx("time"))
 
-    # We need to calculate how much zero padding there was so we know what to expect in the output.
-    if zero_pad_until == "input":
-        # As we are using zero_pad_until = "input", our padding is win_len - block_size
-        zero_pad = max(0, win_len - block_size)
-    else:  # "full"
-        zero_pad = win_len
+    # Calculate the expected results for comparison.
+    sent_data = np.arange(num_msgs * msg_block_size)[None, :]
+    expected, tvec = calculate_expected_results(sent_data, fs, win_shift, zero_pad, msg_block_size, shift_len, win_len,
+                                                1, data_len, num_msgs, 0)
 
-    # Check data
-    assert data.shape[concat_ax] == len(messages)
-    expected_counts = np.arange(num_msgs * block_size + zero_pad).astype(float) - zero_pad
-    expected_data = sliding_window_view(expected_counts, (win_len,))
-    if win_shift is None:
-        expected_data = expected_data[max(0, block_size - win_len)::block_size]
-    else:
-        expected_data = expected_data[::shift_len][:data.shape[concat_ax]]
-    assert np.array_equal(data, np.clip(expected_data[..., None], 0, None))
-
-    # Check offsets
-    expected_offsets = expected_data[:, 0] / in_fs
-    assert np.allclose(offsets, expected_offsets)
+    # Compare results to expected
+    assert np.array_equal(data, expected)
+    assert np.allclose(offsets, tvec)
 
     ez.logger.info("Test Complete.")
 


### PR DESCRIPTION
Note - this is based off #62 and requires #62 to be valid. Of the 4 commits (so far), only the 2nd and 3rd are in question, as the first is from the other PR and the 4th is a cherry-pick from another PR that was already merged into `main`, but not `dev` (and I need it in `dev`).

In this PR, I...

* Expanded the sigproc.Window unit tests which revealed a bunch of failures.
    * The expansion to the tests look at the time (or newaxis) .offset values, and the data assuming Counter is correct.
* Refactored sigproc.Window to satisfy the tests.

I also noticed that the initialization of the buffer creates a `window`-length buffer that's all zeros. Then, when new data comes in, the first window out comes only from the initialized zeros! I highly doubt that we want a completely fabricated window as the first window through the pipeline.

I added a new `zero_pad_until` setting.
* "full" (default), maintains the current behaviour, though maybe that shouldn't be the default.
* "shift" fills the buffer with zeros except for the space required for a single shift, meaning that the first window out will have exactly a single window-shift's worth of real data.
* "input" fills the buffer with zeros but leaves room for the input. In this mode, the first yielded window will have as much of the input data as possible. IMO this should be the default because it provides minimal latency.
* "none" does not use zero-padding in the buffer. There will not be any windows yielded until we have received enough messages to fill at least 1 windows.
