### PR TITLE
Pass Unit args and kwargs to SETTINGS if settings not provided explicitly

### DIFF
--- a/src/ezmsg/core/collection.py
+++ b/src/ezmsg/core/collection.py
@@ -36,8 +36,8 @@ class CollectionMeta(ComponentMeta):
 class Collection(Component, metaclass=CollectionMeta):
     """Collections can contain subunits and connect them together"""
 
-    def __init__(self, settings: typing.Optional[Settings] = None):
-        super(Collection, self).__init__(settings)
+    def __init__(self, *args, settings: typing.Optional[Settings] = None, **kwargs):
+        super(Collection, self).__init__(*args, settings=settings, **kwargs)
 
         self._components = deepcopy(self.__class__.__components__)
         for comp_name, comp in self.components.items():

--- a/src/ezmsg/core/component.py
+++ b/src/ezmsg/core/component.py
@@ -81,7 +81,7 @@ class Component(Addressable, metaclass=ComponentMeta):
     _main: Optional[Callable[..., None]]
     _threads: Dict[str, Callable]
 
-    def __init__(self, settings: Optional[Settings] = None):
+    def __init__(self, *args, settings: Optional[Settings] = None, **kwargs):
         super(Component, self).__init__()
 
         self.SETTINGS = None  # type: ignore
@@ -97,10 +97,16 @@ class Component(Addressable, metaclass=ComponentMeta):
             setattr(self, stream_name, stream)
 
         try:
-            # If we weren't supplied settings, we will try to
-            # instantiate the settings type from annotations
             if settings is None:
-                settings = self.__class__.__settings_type__()
+                # settings not supplied as a kwarg. Try to build it.
+                if len(args) > 0 and type(args[0]) == self.__class__.__settings_type__:
+                    settings = args[0]
+                elif len(args) > 0 or len(kwargs) > 0:
+                    settings = self.__class__.__settings_type__(*args, **kwargs)
+                else:
+                    # If we weren't supplied settings, we will try to
+                    # instantiate the settings type from annotations
+                    settings = self.__class__.__settings_type__()
         except TypeError:
             # We couldn't instantiate settings with default value
             # We will rely on late configuration via apply_settings

--- a/src/ezmsg/core/unit.py
+++ b/src/ezmsg/core/unit.py
@@ -61,8 +61,8 @@ class UnitMeta(ComponentMeta):
 class Unit(Component, metaclass=UnitMeta):
     """Units can subscribe, publish, and have tasks"""
 
-    def __init__(self, settings: Optional[Settings] = None):
-        super(Unit, self).__init__(settings)
+    def __init__(self, *args, settings: Optional[Settings] = None, **kwargs):
+        super(Unit, self).__init__(*args, settings=settings, **kwargs)
 
         for task_name, task in self.__class__.__tasks__.items():
             self._tasks[task_name] = task

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -150,3 +150,34 @@ def test_local_system(toy_system_fixture, num_messages):
             results.append(json.loads(line))
     os.remove(test_filename)
     assert len(results) == num_messages
+
+
+@pytest.mark.parametrize("passthrough_settings", [False, True])
+@pytest.mark.parametrize("num_messages", [1, 5, 10])
+def test_run_comps_conns(passthrough_settings, num_messages):
+    test_filename = get_test_fn()
+    if passthrough_settings:
+        comps = {
+            "SIMPLE_PUB": MessageGenerator(num_msgs=num_messages),
+            "SIMPLE_SUB": MessageReceiver(num_msgs=num_messages, output_fn=test_filename)
+        }
+    else:
+        comps = {
+            "SIMPLE_PUB": MessageGenerator(MessageGeneratorSettings(num_msgs=num_messages)),
+            "SIMPLE_SUB": MessageReceiver(MessageReceiverSettings(
+                num_msgs=num_messages, output_fn=test_filename
+            ))
+        }
+    conns = (
+        (comps["SIMPLE_PUB"].OUTPUT, comps["SIMPLE_SUB"].INPUT),
+    )
+
+    ez.run(components=comps, connections=conns)
+
+    results = []
+    with open(test_filename, "r") as file:
+        lines = file.readlines()
+        for line in lines:
+            results.append(json.loads(line))
+    os.remove(test_filename)
+    assert len(results) == num_messages

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -181,3 +181,23 @@ def test_run_comps_conns(passthrough_settings, num_messages):
             results.append(json.loads(line))
     os.remove(test_filename)
     assert len(results) == num_messages
+
+
+@pytest.mark.parametrize("passthrough_settings", [False, True])
+@pytest.mark.parametrize("num_messages", [1, 5, 10])
+def test_run_collection(passthrough_settings, num_messages):
+    test_filename = get_test_fn()
+    if passthrough_settings:
+        collection = ToySystem(num_msgs=num_messages, output_fn=test_filename)
+    else:
+        collection = ToySystem(
+            ToySystemSettings(num_msgs=num_messages, output_fn=test_filename)
+        )
+    ez.run(collection)
+    results = []
+    with open(test_filename, "r") as file:
+        lines = file.readlines()
+        for line in lines:
+            results.append(json.loads(line))
+    os.remove(test_filename)
+    assert len(results) == num_messages


### PR DESCRIPTION

Settings are typically passed to a Unit upon instantiation as follows (e.g.)

```Python
from ezmsg.sigproc.downsample import DownsampleSettings, Downsample

ds_unit = Downsample(DownsampleSettings(axis="time", factor=10))
```

With this change, we can alternatively pass the settings parameters directly to the Unit (without the __Settings class) and they will be used to initialize the settings. i.e.,

```Python
from ezmsg.sigproc.downsample import Downsample

ds_unit = Downsample(axis="time", factor=10)
```

It's just a little quality-of-life improvement that makes the entry-point scripts cleaner.

Fixes #71 
