### PR TITLE
Move timestamp addtion from codec to logger/replay

### DIFF
--- a/src/ezmsg/util/messagecodec.py
+++ b/src/ezmsg/util/messagecodec.py
@@ -120,10 +120,15 @@ class MessageDecoder(json.JSONDecoder):
         return out_obj
 
 
-def message_log(fname: Path) -> typing.Generator[typing.Any, None, None]:
+def message_log(
+    fname: Path, return_object: bool = True
+) -> typing.Generator[typing.Any, None, None]:
     with open(fname, "r") as f:
         for l in f:
             obj = json.loads(l, cls=MessageDecoder)
             if isinstance(obj, LogStart):
                 continue
-            yield obj
+            if return_object is True:
+                yield obj["obj"]
+            else:
+                yield obj

--- a/src/ezmsg/util/messagecodec.py
+++ b/src/ezmsg/util/messagecodec.py
@@ -24,6 +24,7 @@ NDARRAY_DTYPE = "dtype"
 NDARRAY_SHAPE = "shape"
 NDARRAY_DATA = "data"
 
+
 @dataclass
 class LogStart:
     ...
@@ -49,10 +50,9 @@ def import_type(typestr: str) -> type:
 class MessageEncoder(json.JSONEncoder):
     def default(self, obj: typing.Any):
         if is_dataclass(obj):
-            ts = getattr(obj, TIMESTAMP_ATTR, time.time())
             return {
-                **{f.name: getattr(obj, f.name) for f in fields(obj)}, 
-                **{TYPE: type_str(obj), TIMESTAMP_ATTR: ts}
+                **{f.name: getattr(obj, f.name) for f in fields(obj)},
+                **{TYPE: type_str(obj)},
             }
 
         elif np and isinstance(obj, np.ndarray):
@@ -67,7 +67,7 @@ class MessageEncoder(json.JSONEncoder):
 
         try:
             return json.JSONEncoder.default(self, obj)
-        
+
         except TypeError:
             buf = base64.b64encode(pickle.dumps(obj))
             return {
@@ -75,24 +75,27 @@ class MessageEncoder(json.JSONEncoder):
                 PICKLE_DATA: buf.decode("ascii"),
             }
 
+
 class StampedMessage(typing.NamedTuple):
     msg: typing.Any
     timestamp: typing.Optional[float]
 
-class MessageTimestampDecoder(json.JSONDecoder):
+
+class MessageDecoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
         json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
 
     def object_hook(self, obj: typing.Dict[str, typing.Any]) -> typing.Any:
-        obj_type: typing.Optional[str] = obj.get(TYPE, None)
-        timestamp: typing.Optional[float] = obj.get(TIMESTAMP_ATTR, None)
+        obj_type: typing.Optional[str] = obj.get(TYPE)
 
         out_obj: typing.Any = obj
 
         if obj_type is not None:
             if np and obj_type == NDARRAY_TYPE:
                 data_bytes: typing.Optional[str] = obj.get(NDARRAY_DATA)
-                data_shape: typing.Optional[typing.Iterable[int]] = obj.get(NDARRAY_SHAPE)
+                data_shape: typing.Optional[typing.Iterable[int]] = obj.get(
+                    NDARRAY_SHAPE
+                )
                 data_dtype: typing.Optional[npt.DTypeLike] = obj.get(NDARRAY_DTYPE)
 
                 if (
@@ -102,7 +105,7 @@ class MessageTimestampDecoder(json.JSONDecoder):
                 ):
                     buf = base64.b64decode(data_bytes.encode("ascii"))
                     out_obj = np.frombuffer(buf, dtype=data_dtype).reshape(data_shape)
-                
+
             elif obj_type == PICKLE_TYPE:
                 data_bytes: typing.Optional[str] = obj.get(PICKLE_DATA)
                 if isinstance(data_bytes, str):
@@ -112,22 +115,10 @@ class MessageTimestampDecoder(json.JSONDecoder):
             else:
                 cls = import_type(obj_type)
                 del obj[TYPE]
-                if TIMESTAMP_ATTR in obj: 
-                    del obj[TIMESTAMP_ATTR]
                 out_obj = cls(**obj)
-                if timestamp is not None:
-                    setattr(out_obj, TIMESTAMP_ATTR, timestamp)
 
         return out_obj
-    
-class MessageDecoder(MessageTimestampDecoder):
-    """ Just in case there are side-effects from adding the timestamp attribute """
-    def object_hook(self, obj: typing.Dict[str, typing.Any]) -> typing.Any:
-        obj = super().object_hook(obj)
-        if hasattr(obj, TIMESTAMP_ATTR):
-            delattr(obj, TIMESTAMP_ATTR)
-        return obj
-    
+
 
 def message_log(fname: Path) -> typing.Generator[typing.Any, None, None]:
     with open(fname, "r") as f:

--- a/src/ezmsg/util/messagelogger.py
+++ b/src/ezmsg/util/messagelogger.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 from io import TextIOWrapper
 from dataclasses import field
@@ -10,7 +11,7 @@ from .messagecodec import MessageEncoder, LogStart
 
 from typing import Optional, Any, Dict, AsyncGenerator, Any
 
-    
+
 class MessageLoggerSettings(ez.Settings):
     output: Optional[Path] = None
 
@@ -79,7 +80,9 @@ class MessageLogger(ez.Unit):
     @ez.subscriber(INPUT_MESSAGE)
     @ez.publisher(OUTPUT_MESSAGE)
     async def on_message(self, message: Any) -> AsyncGenerator:
-        strmessage: str = json.dumps(message, cls=MessageEncoder)
+        strmessage: str = json.dumps(
+            {"ts": time.time(), "obj": message}, cls=MessageEncoder
+        )
         for output_f in self.STATE.output_files.values():
             output_f.write(f"{strmessage}\n")
             output_f.flush()

--- a/src/ezmsg/util/messagereplay.py
+++ b/src/ezmsg/util/messagereplay.py
@@ -50,7 +50,7 @@ class MessageReplay(ez.Unit):
 
     OUTPUT_REPLAY_STATUS = ez.OutputStream(ReplayStatusMessage)
 
-    def initialize(self) -> None:
+    async def initialize(self) -> None:
         self.STATE.replay_files = asyncio.Queue()
         if self.SETTINGS.filename is not None:
             self.STATE.replay_files.put_nowait(self.SETTINGS)
@@ -126,9 +126,6 @@ class MessageReplay(ez.Unit):
                             f"Could not load line {line_idx} from {self.SETTINGS.filename}"
                         )
                     else:
-                        if isinstance(msg, LogStart):
-                            continue
-
                         ts = msg["ts"]
                         obj = msg["obj"]
                         if last_msg_t is None and ts is not None:
@@ -154,6 +151,9 @@ class MessageReplay(ez.Unit):
                                     )
                                     await asyncio.sleep(sleep_time)
                                 last_msg_t = ts
+
+                        if isinstance(obj, LogStart):
+                            continue
 
                         yield self.OUTPUT_MESSAGE, obj
                         pub_msgs += 1


### PR DESCRIPTION
Remove timestamp from messagecodec JSON encoder. Instead, wrap top-level objects in dict with `ts` and `obj` fields. This solves a few issues:
1. MessageEncoder assigning different timestamps for a dataclass object and any children dataclass objects
2. MessageEncoder/Decoder previously failed on messages that were not dataclasses.