### PR TITLE
`windowing` generator now yields AxisArray. 

### DIFF
--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/sampler.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/sampler.py
@@ -97,8 +97,8 @@ def sampler(
                 continue
 
             # Check that period is compatible with buffer duration.
-            max_buf_len = int(buffer_dur * fs)
-            req_buf_len = int((_period[1] - _period[0]) * fs)
+            max_buf_len = int(np.round(buffer_dur * fs))
+            req_buf_len = int(np.round((_period[1] - _period[0]) * fs))
             if req_buf_len >= max_buf_len:
                 ez.logger.warning(
                     f"Sampling failed: {period=} >= {buffer_dur=}"
@@ -164,7 +164,7 @@ def sampler(
                 t_start = trig.timestamp + trig.period[0]
                 if t_start >= buffer_offset[0]:
                     start = np.searchsorted(buffer_offset, t_start)
-                    stop = start + int(fs * (trig.period[1] - trig.period[0]))
+                    stop = start + int(np.round(fs * (trig.period[1] - trig.period[0])))
                     if buffer.shape[axis_idx] > stop:
                         # Trigger period fully enclosed in buffer.
                         msg_out.append(

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/spectrogram.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/spectrogram.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import ezmsg.core as ez
 from ezmsg.util.messages.axisarray import AxisArray
-from ezmsg.util.generator import consumer, GenAxisArray  # , compose
+from ezmsg.util.generator import consumer, GenAxisArray, compose
 from ezmsg.util.messages.modify import modify_axis
 from ezmsg.sigproc.window import windowing
 from ezmsg.sigproc.spectrum import (
@@ -40,13 +40,11 @@ def spectrogram(
         and yields an AxisArray of time-frequency power values.
     """
 
-    # We cannot use `compose` because `windowing` returns a list of axisarray objects,
-    #  even though the length is always exactly 1 for the settings used here.
-    # pipeline = compose(
-    f_win = windowing(axis="time", newaxis="step", window_dur=window_dur, window_shift=window_shift)
-    f_spec = spectrum(axis="time", window=window, transform=transform, output=output)
-    f_modify = modify_axis(name_map={"step": "time"})
-    # )
+    pipeline = compose(
+        windowing(axis="time", newaxis="win", window_dur=window_dur, window_shift=window_shift),
+        spectrum(axis="time", window=window, transform=transform, output=output),
+        modify_axis(name_map={"win": "time"})
+    )
 
     # State variables
     axis_arr_in = AxisArray(np.array([]), dims=[""])
@@ -54,14 +52,7 @@ def spectrogram(
 
     while True:
         axis_arr_in = yield axis_arr_out
-
-        # axis_arr_out = pipeline(axis_arr_in)
-        axis_arr_out = None
-        wins = f_win.send(axis_arr_in)
-        if len(wins):
-            specs = f_spec.send(wins[0])
-            if specs is not None:
-                axis_arr_out = f_modify.send(specs)
+        axis_arr_out = pipeline(axis_arr_in)
 
 
 class SpectrogramSettings(ez.Settings):

--- a/extensions/ezmsg-sigproc/tests/test_spectrogram.py
+++ b/extensions/ezmsg-sigproc/tests/test_spectrogram.py
@@ -66,7 +66,7 @@ def test_spectrogram():
     )
 
     results = [gen.send(msg) for msg in messages]
-    results = [_ for _ in results if _ is not None]  # Drop None
+    results = [_ for _ in results if _.data.size]  # Drop empty messages
 
     # Check that the windows span the expected times.
     expected_t_span = 2 * seg_dur


### PR DESCRIPTION
Fixes #100 

The `windowing` generator now _always_ yields an `AxisArray`.

Previously, the return type was `List[AxisArray]`. Depending on the configuration, the list might have always been length 1 (in 1:1 mode) or usually 1, unless a big chunk came in and multiple windows were available.
Now, there is always a `newaxis` added ("win" by default) and that will usually have length 1, but sometimes more.

The "win" axis might also have length 0 when the most recent `send` was inadequate to fill the next window. Previously, an unfilled `.send` would yield `None` (previous yield type incorrectly failed to include `Optional[...]`). This is probably the biggest change here and might merit some discussion:
_What should generators yield when the `.send` does not provide enough data to yield a result?_ `None`, an empty `AxisArray`, or an `AxisArray` with most details correct except one dimension is `0` and `msg.data.size==0`?

The Unit still has the option for the setting `newaxis=None`, in which case the value yielded by the generator is iterated over the "win" axis. In cases where the "win" axis is length 0, nothing is iterated (i.e., nothing published).

I had to make a change to the generator-level tests to drop yielded msgs with size 0, whereas previously I was dropping yielded msgs that were None.

The system-level tests are unchanged and continue to pass. If you have a use case that doesn't work with this PR then please create a test for that and I will try to figure out a solution.