### PR TITLE
Big docs update

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,240 +1,84 @@
 API
 ===
 
-An ``ezmsg`` pipeline is created from a few basic components. ``ezmsg`` provides a framework for you to define your own graphs using its building blocks. Inherit from its base components to define a pipeline that works for your project.
+An ``ezmsg`` pipeline is created from a few basic components.
+``ezmsg`` provides a framework for you to define your own graphs using its building blocks.
+Inherit from its base components to define a pipeline that works for your project.
 
+.. automodule:: ezmsg.core
 
-Collection
+Most ``ezmsg`` classes intended for use in building pipelines are available in ``ezmsg.core``.
+It is convention to ``import ezmsg.core as ez`` and then use this shorthand in your code. e.g.,
+
+.. code-block:: python
+
+   class MyUnit(ez.Unit):
+       ...
+
+Components
 ----------
 
-Connects ``Units`` together by defining a graph which connects ``OutputStreams`` to ``InputStreams``.
+.. autoclass:: Component
 
-Lifecycle Hooks
-^^^^^^^^^^^^^^^
+.. autoclass:: Collection
+   :show-inheritance:
+   :members:
 
-The following lifecycle hooks in the ``Collection`` class can be overridden:
+.. autoclass:: NetworkDefinition
 
-.. py:method:: configure( self )
-
-   Runs when the ``Collection`` is instantiated. This is the best place to call ``Unit.apply_settings()`` on each member ``Unit`` of the ``Collection``.
-
-Overridable Methods
-^^^^^^^^^^^^^^^^^^^^
-
-.. py:method:: network( self ) -> NetworkDefinition
-
-   In this method, define and return a ``NetworkDefinition`` which defines how ``InputStreams`` and ``OutputStreams`` from member ``Units`` will be connected.
-
-.. py:method:: process_components( self ) -> Tuple[Unit|Collection, ...]
-
-   In this method, define and return a tuple which contains ``Units`` and ``Collections`` which should run in their own processes.
-
-Component
----------
-
-Metaclass which ``Units`` and ``Collections`` inherit from.
-
-Complete
---------
-
-.. py:class:: Complete
-
-   A type of ``Exception`` which signals to ``ezmsg`` that the function can be shut down gracefully. If all functions in all ``Units`` raise ``Complete``, the entire pipeline will terminate execution.
+.. autoclass:: Unit
+   :show-inheritance:
+   :members:
+   :inherited-members:
 
 
-NetworkDefinition
-------------------
+Unit Function Decorators
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. py:class:: NetworkDefinition
+These function decorators can be added to member functions.
 
-   Wrapper on ``Iterator[Tuple[OutputStream, InputStream]]``.
+.. automethod:: ezmsg.core.subscriber
+
+.. automethod:: ezmsg.core.publisher
+
+.. automethod:: ezmsg.core.main
+
+.. automethod:: unit.thread
+
+.. automethod:: ezmsg.core.task
+
+.. automethod:: ezmsg.core.process
+
+.. automethod:: ezmsg.core.timeit
 
 
-NormalTermination
------------------
+Component Interaction
+---------------------
 
-.. py:class:: NormalTermination
+.. autoclass:: Settings
 
-   A type of ``Exception`` which signals to ``ezmsg`` that the pipeline can be shut down gracefully. 
+.. autoclass:: State
 
-run
----
-
-.. py:method:: run(components: {str: Component} = None, root_name: str = None, connections: NetworkDefinition = None, process_components: [Component] = None, backend_process: BackendProcess = DefaultBackendProcess, graph_address: (str, int) = None, force_single_process: bool = False, **components_kwargs: Component) -> None
-
-   `The old method` run_system() `has been deprecated and uses` run() `instead.`
-
-   Begin execution of a set of ``Components``.
-
-   `components` represents the nodes in the directed acyclic graph. It is a dictionary which contains the ``Components`` to be run mapped to string names. On initialization, ``ezmsg`` will call ``initialize()`` for each ``Unit`` and ``configure()`` for each ``Collection``, if defined.
-
-   `connections` represents the edges is a ``NetworkDefinition`` which connects ``OutputStreams`` to ``InputStreams``. On initialization, ``ezmsg`` will create a directed acyclic graph using the contents of this parameter.
-
-   `process_components` is a list of ``Components`` which should live in their own process.
-
-   `backend_process` is currently under development.
-
-   `graph_address` is a tuple which contains the hostname and port of the graph server which ``ezmsg`` should connect to. If not defined, ``ezmsg`` will start a new graph server at 127.0.0.1:25978. 
-
-   `force_single_process` will run all ``Components`` in one process. This is necessary when running ``ezmsg`` in a notebook.
-
-Settings
---------
-
-To pass parameters into a ``Component``, inherit from ``Settings``.
-
-.. code-block:: python
-
-   class YourSettings(Settings): 
-      setting1: int
-      setting2: float
-
-To use, declare the ``Settings`` object for a ``Component`` as a member variable called (all-caps!) ``SETTINGS``. ``ezmsg`` will monitor the variable called ``SETTINGS`` in the background, so it is important to name it correctly.
-
-.. code-block:: python
-
-   class YourUnit(Unit):
-
-      SETTINGS: YourSettings
-
-A ``Unit`` can accept a ``Settings`` object as a parameter on instantiation.
-
-.. code-block:: python
-
-   class YourCollection(Collection):
-
-      YOUR_UNIT = YourUnit(
-         YourSettings(
-            setting1: int,
-            setting2: float
-         )
-      )
-
-.. note:: 
-   ``Settings`` uses type hints to define member variables, but does not enforce type checking.
-
-State
------
-
-To track a mutable state for a ``Component``, inherit from ``State``.
-
-.. code-block:: python
-
-   class YourState(State):
-      state1: int
-      state2: float
-
-To use, declare the ``State`` object for a ``Component`` as a member variable called (all-caps!) ``STATE``. ``ezmsg`` will monitor the variable called ``STATE`` in the background, so it is important to name it correctly.
-
-Member functions can then access and mutate ``STATE`` as needed during function execution. It is recommended to initialize state values inside the ``initialize()`` or ``configure()`` lifecycle hooks if defaults are not defined.
-
-.. code-block:: python
-
-   class YourUnit(Unit):
-
-      STATE: YourState
-
-      def initialize(self):
-         this.STATE.state1 = 0
-         this.STATE.state2 = 0.0
-
-.. note:: 
-   ``State`` uses type hints to define member variables, but does not enforce type checking.
 
 Stream
 ------
 
-Facilitates a flow of ``Messages`` into or out of a ``Component``. 
+Facilitates a flow of ``Messages`` into or out of a ``Component``.
 
-.. class:: InputStream(Message)
+.. autoclass:: InputStream
 
-   Can be added to any ``Component`` as a member variable. Methods may subscribe to it.
-
-
-.. class:: OutputStream(Message)
-
-   Can be added to any ``Component`` as a member variable. Methods may publish to it.
+.. autoclass:: OutputStream
 
 
-Unit
-----
+Custom Exceptions
+-----------------
 
-Represents a single step in the graph. To create a ``Unit``, inherit from the ``Unit`` class.
+.. autoclass:: Complete
 
-Lifecycle Hooks
-^^^^^^^^^^^^^^^
+.. autoclass:: NormalTermination
 
-The following lifecycle hooks in the ``Unit`` class can be overridden. Both can be run as ``async`` functions by simply adding the ``async`` keyword when overriding.
 
-.. py:method:: initialize( self ) 
+Entry Point
+-----------
 
-   Runs when the ``Unit`` is instantiated.
-
-.. py:method:: shutdown( self )
-
-   Runs when the ``Unit`` terminates.
-
-Function Decorators
-^^^^^^^^^^^^^^^^^^^
-
-These function decorators can be added to member functions.
-
-.. py:method:: @subscriber(InputStream)
-
-   An async function will run once per message received from the ``InputStream`` it subscribes to. Example:
-
-   .. code-block:: python
-
-      INPUT = ez.InputStream(Message)
-
-      @subscriber(INPUT)
-      async def print_message(self, message: Message) -> None:
-         print(message)
-   
-   A function can have both ``@subscriber`` and ``@publisher`` decorators.
-
-.. py:method:: @publisher(OutputStream)
-
-   An async function will yield messages on the designated ``OutputStream``.
-
-   .. code-block:: python
-
-      from typing import AsyncGenerator
-
-      OUTPUT = OutputStream(ez.Message)
-
-      @publisher(OUTPUT)
-      async def send_message(self) -> AsyncGenerator:
-         message = Message()
-         yield(OUTPUT, message)
-
-   A function can have both ``@subscriber`` and ``@publisher`` decorators.
-
-.. py:method:: @main
-
-   Designates this function to run as the main thread for this ``Unit``. A ``Unit`` may only have one of these.
-
-.. py:method:: @thread
-
-   Designates this function to run as a background thread for this ``Unit``.
-
-.. py:method:: @task 
-
-   Designates this function to run as a task in the task/messaging thread.
-
-.. py:method:: @process
-
-   Designates this function to run in its own process.
-
-.. py:method:: @timeit
-
-   ``ezmsg`` will log the amount of time this function takes to execute.
-
-Public Methods
-^^^^^^^^^^^^^^
-
-A class which inherits from ``Unit`` also inherits one public method:
-
-.. function:: Unit.apply_settings( self, settings: Settings )
-
-   Update a ``Unit`` 's ``Settings`` object.
+.. automethod:: ezmsg.core.run

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,5 +62,8 @@ def linkcode_resolve(domain, info):
     filename = info['module'].replace('.', '/')
     if "sigproc" in filename:
         return f"{code_url}extensions/ezmsg-sigproc/src/{filename}.py"
+    elif "core" in filename:
+        return f"{code_url}src/ezmsg/core/__init__.py"
     else:
         return f"{code_url}src/{filename}.py"
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,10 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../../src'))
+sys.path.insert(0, os.path.abspath('../../extensions/ezmsg-sigproc/src'))
+# sys.path.insert(0, os.path.abspath('../../extensions/ezmsg-websocket/src'))
+# sys.path.insert(0, os.path.abspath('../../extensions/ezmsg-zmq/src'))
+
 # Configuration file for the Sphinx documentation builder.
 
 # -- Project information
@@ -6,8 +13,8 @@ project = "ezmsg"
 copyright = "2022, JHU/APL"
 author = "JHU/APL"
 
-release = "3.0"
-version = "3.0.0"
+release = "3.3.4"
+version = "3.3.4"
 
 # -- General configuration
 
@@ -17,6 +24,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon"
 ]
 
 intersphinx_mapping = {
@@ -33,3 +41,5 @@ html_theme = "sphinx_rtd_theme"
 
 # -- Options for EPUB output
 epub_show_urls = "footnote"
+
+add_module_names = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,8 @@
 import os
 import sys
+import importlib
+import inspect
+
 sys.path.insert(0, os.path.abspath('../../src'))
 sys.path.insert(0, os.path.abspath('../../extensions/ezmsg-sigproc/src'))
 # sys.path.insert(0, os.path.abspath('../../extensions/ezmsg-websocket/src'))
@@ -24,12 +27,15 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.linkcode",
     "sphinx.ext.napoleon"
 ]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
+    "numpy": ("https://docs.scipy.org/doc/numpy", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
 }
 intersphinx_disabled_domains = ["std"]
 
@@ -43,3 +49,18 @@ html_theme = "sphinx_rtd_theme"
 epub_show_urls = "footnote"
 
 add_module_names = False
+
+
+code_url = f"https://github.com/iscoe/ezmsg/blob/dev/"
+
+
+def linkcode_resolve(domain, info):
+    if domain != 'py':
+        return None
+    if not info['module']:
+        return None
+    filename = info['module'].replace('.', '/')
+    if "sigproc" in filename:
+        return f"{code_url}extensions/ezmsg-sigproc/src/{filename}.py"
+    else:
+        return f"{code_url}src/{filename}.py"

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -1,2 +1,7 @@
 Extensions
 ==========
+
+.. toctree::
+   :maxdepth: 1
+
+   extensions/sigproc

--- a/docs/source/extensions/sigproc.rst
+++ b/docs/source/extensions/sigproc.rst
@@ -1,0 +1,114 @@
+ezmsg-sigproc
+=============
+
+ezmsg.sigproc.affinetransform
+-----------------------------
+
+.. automodule:: ezmsg.sigproc.affinetransform
+    :members:
+
+
+ezmsg.sigproc.aggregate
+-----------------------
+
+.. automodule:: ezmsg.sigproc.aggregate
+    :members:
+    :undoc-members:
+
+
+ezmsg.sigproc.bandpower
+-----------------------
+
+.. automodule:: ezmsg.sigproc.bandpower
+    :members:
+
+
+ezmsg.sigproc.filter
+--------------------
+
+.. automodule:: ezmsg.sigproc.filter
+    :members:
+
+ezmsg.sigproc.butterworthfilter
+-------------------------------
+
+.. automodule:: ezmsg.sigproc.butterworthfilter
+    :members:
+
+
+ezmsg.sigproc.decimate
+----------------------
+
+.. automodule:: ezmsg.sigproc.decimate
+    :members:
+
+
+ezmsg.sigproc.downsample
+------------------------
+
+.. automodule:: ezmsg.sigproc.downsample
+    :members:
+
+
+ezmsg.sigproc.ewmfilter
+-----------------------
+
+.. automodule:: ezmsg.sigproc.ewmfilter
+    :members:
+
+
+ezmsg.sigproc.sampler
+---------------------
+
+.. automodule:: ezmsg.sigproc.sampler
+    :members:
+
+
+ezmsg.sigproc.scaler
+--------------------
+
+.. automodule:: ezmsg.sigproc.scaler
+    :members:
+
+
+ezmsg.sigproc.signalinjector
+----------------------------
+
+.. automodule:: ezmsg.sigproc.signalinjector
+    :members:
+
+
+ezmsg.sigproc.slicer
+---------------------
+
+.. automodule:: ezmsg.sigproc.slicer
+    :members:
+
+
+ezmsg.sigproc.spectrum
+----------------------
+
+.. automodule:: ezmsg.sigproc.spectrum
+    :members:
+    :undoc-members:
+
+
+ezmsg.sigproc.spectrogram
+-------------------------
+
+.. automodule:: ezmsg.sigproc.spectrogram
+    :members:
+
+
+ezmsg.sigproc.synth
+-------------------
+
+.. automodule:: ezmsg.sigproc.synth
+    :members:
+
+
+ezmsg.sigproc.window
+--------------------
+
+.. automodule:: ezmsg.sigproc.window
+    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,3 +27,4 @@ Contents
    api
    utils
    other
+   extensions

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -3,6 +3,13 @@ Utility Classes
 
 Classes which implement functionality which is commonly useful for ``ezmsg`` pipelines.
 
+AxisArray
+---------
+
+.. automodule:: ezmsg.util.messages.axisarray
+   :show-inheritance:
+   :members:
+
 DebugLog
 --------
 

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -6,307 +6,46 @@ Classes which implement functionality which is commonly useful for ``ezmsg`` pip
 DebugLog
 --------
 
-Inherits from ``Units``. Logs messages that pass through.
+.. automodule:: ezmsg.util.debuglog
+   :show-inheritance:
+   :members:
 
-Input/OutputStreams
-^^^^^^^^^^^^^^^^^^^
 
-.. object:: INPUT
+MessageReplay
+-------------
 
-   `Type:` ``InputStream(Any)``
-
-   Send messages to log here.
-
-.. object:: OUTPUT
-
-   `Type:` ``OutputStream(Any)``
-
-   Send messages back out to continue through the graph.
-
-Settings
-^^^^^^^^
-
-.. py:class:: DebugLogSettings(name: str = "DEBUG", max_length: Optional[int] = 400)
-
-   Inherits from ``Settings``. Define to customize.
-
-   `name` is included in the logstring so that if multiple DebugLogs are used in one pipeline, their messages can be differentiated.
-
-   `max_length` sets a maximum number of chars which will be printed from the message. If the message is longer, the log message will be truncated.
-
-Message Collector
------------------
-
-Inherits from ``Unit``. Collects ``Messages`` into a local list.
-
-Input/OutputStreams
-^^^^^^^^^^^^^^^^^^^
-
-.. object:: INPUT_MESSAGE
-
-   Send messages here to be collected.
-
-.. object:: OUTPUT_MESSAGE
-
-   Messages will pass straight through after being recorded and be published here.
-
-Methods
-^^^^^^^
-
-.. py:method:: messages() -> [Any]
-
-   Returns a list of messages which have been collected.
+.. automodule:: ezmsg.util.messagereplay
+   :show-inheritance:
+   :members:
 
 
 MessageGate
 -----------
 
-Inherits from ``Unit``. Blocks ``Messages`` from continuing through the system. Can be set as open, closed, open after n messages, or closed after n messages.
+.. automodule:: ezmsg.util.messagegate
+   :show-inheritance:
+   :members:
 
-Messages
-^^^^^^^^
-
-.. py:class:: GateMessage(open: bool)
-   
-   Send this message to ``INPUT_GATE`` to open or close the gate.
-
-Input/OutputStreams
-^^^^^^^^^^^^^^^^^^^
-
-.. object:: INPUT_GATE
-
-   `Type:` ``InputStream(GateMessage)``
-
-   Stop or start message flow. If ``GateMessage.open == True``, messages will flow through. If ``GateMessage.open == False``, messages will be discarded. 
-
-.. object:: INPUT
-
-   `Type:` ``InputStream(Any)``
-
-   Messages which will flow through or be discarded, depending on gate status.
-
-.. object:: OUTPUT
-
-   `Type`: ``OutputStream(Any)``
-
-   Publishes messages which flow through.
-
-Settings
-^^^^^^^^
-
-.. py:class:: MessageGateSettings(start_open: bool = False, default_open: bool = False, default_after: Optional[int] = None)
-
-   Inherits from ``Settings``. Define to customize ``MessageGate`` behavior.
-
-   `start_open` sets the gate's initial state to allow messages to flow through or be discarded. ``True`` will allow messages to flow through initially, ``False`` will discard messages initially.
-
-   `default_open` sets the gate's behavior after the `default_after` number of messages have flowed through. ``True`` will allow messages to flow through, ``False`` will discard messages.
-
-   `default_after` sets the number of messages after which the `default_open` state will be applied.
 
 MessageLogger
 -------------
 
-Inherits from ``Unit``. Logs all messages it receives to a file. File path can be set in ``SETTINGS`` or set dynamically by passing a `pathlib.Path <https://docs.python.org/3/library/pathlib.html#basic-use>`_ to ``INPUT_START``.
+.. automodule:: ezmsg.util.messagelogger
+   :show-inheritance:
+   :members:
 
-Input/OutputStreams
-^^^^^^^^^^^^^^^^^^^
-
-.. object:: INPUT_START
-
-   `Type:` ``InputStream(pathlib.Path)``
-
-   Pass a `pathlib.Path <https://docs.python.org/3/library/pathlib.html#basic-use>`_ to begin logging messages to that path. If the file path already exists, the existing file will be truncated to 0 length. If the file is already open, nothing will happen.
-
-.. object:: INPUT_STOP
-
-   `Type:` ``InputStream(pathlib.Path)``
-
-   Pass a `pathlib.Path <https://docs.python.org/3/library/pathlib.html#basic-use>`_ to stop logging messages to that path.
-
-.. object:: INPUT_MESSAGE
-
-   `Type:` ``InputStream(Any)``
-
-   Pass a piece of data to log it to every open file which the ``MessageLogger`` is using.
-
-.. object:: OUTPUT_MESSAGE
-
-   `Type`: ``OutputStream(Any)``
-
-   Messages which are sent to ``INPUT_MESSAGE`` will pass through and be published on ``OUTPUT_MESSAGE``.
-
-.. object:: OUTPUT_START
-
-   `Type:` ``OutputStream(pathlib.Path)``
-
-   If a file passed to ``INPUT_START`` is successfully opened, its path will be published to ``OUTPUT_START``, otherwise ``None``.
-
-.. object:: OUTPUT_STOP
-
-   `Type:` ``OutputStream(pathlib.Path)``
-
-   If a file passed to ``INPUT_STOP`` is successfully closed, its path will be published to ``OUTPUT_STOP``, otherwise ``None``.
-
-
-Settings
-^^^^^^^^
-
-.. py:class:: MessageLoggerSettings(output: Optional[Path] = None)
-
-   Pass a `pathlib.Path <https://docs.python.org/3/library/pathlib.html#basic-use>`_ for a file where the messages will be logged. If the file path already exists, the existing file will be truncated to 0 length.
 
 MessageQueue
 ------------
 
-Inherits from ``Unit``. Place between two other ``Units`` to induce backpressure.
+.. automodule:: ezmsg.util.messagequeue
+   :show-inheritance:
+   :members:
 
-Input/OutputStreams
-^^^^^^^^^^^^^^^^^^^
 
-.. object:: INPUT
+Terminate
+---------
 
-   `Type:` ``InputStream(Any)``
-
-   Send messages to queue here.
-
-.. object:: OUTPUT
-
-   `Type:` ``OutputStream(Any)``
-
-   Subscribe to pull messages out of the queue.
-
-Settings
-^^^^^^^^
-
-.. py:class:: MessageQueueSettings(maxsize: int = 0, leaky: bool = False)
-
-`maxsize` indicates the maximum number of items which the queue will hold.
-
-`leaky` indicates whether the queue will drop new messages when it reaches its maxsize, or whether it will wait for space to open for them.
-
-MessageReplay
--------------
-
-Inherits from ``Unit``. Stream messages from files created by ``MessageLogger``. Stores a queue of files to stream and streams from them in order.
-
-Messages
-^^^^^^^^
-.. py:class:: ReplayStatusMessage(filename: Path, idx: int, total: int, done: bool = False)
-
-   Message which gives the status of a file replay.
-
-   `filename` is the file currently being replayed.
-
-   `idx` is the line number of the message that was just published.
-
-   `total` is the total number of messages in the file.
-
-   `done` denotes whether the file has finished replaying. 
-
-.. py:class:: FileReplayMessage(filename: Optional[Path] = None, rate: Optional[float] = None)
-
-   Add a file to the queue.
-
-   `filename` is the path of the file to replay.
-
-   `rate` in Hertz at which the messages will be published. If not specified, messages will publish as fast as possible.
-
-Input/OutputStreams
-^^^^^^^^^^^^^^^^^^^
-
-.. object:: INPUT_FILE
-   
-   `Type:` ``InputStream(FileReplayMessage)``
-
-   Add a new file to the queue.
-
-.. object:: INPUT_PAUSED
-   
-   `Type:` ``InputStream(bool)``
-
-   Send ``True`` to pause the stream, ``False`` to restart the stream.
-
-.. object:: INPUT_STOP
-   
-   `Type:` ``InputStream(bool)``
-
-   Stop the stream. Send ``True`` to also clear the queue. Send ``False`` to reset to the beginning of the current file.
-
-.. object:: OUTPUT_MESSAGE
-
-   `Type:` ``OutputStream(Any)``
-
-   The output on which the messages from the files will be streamed.
-
-.. object:: OUTPUT_TOTAL
-   
-   `Type:` ``OutputStream(int)``
-
-   Publishes an integer total of messages which have been published on OUTPUT_MESSAGE from a single file. Resets when a file completes.
-
-.. object:: OUTPUT_REPLAY_STATUS
-
-   `Type:` ``OutputStream(ReplayStatusMessage)``
-
-   Publishes status messages.
-
-Settings
-^^^^^^^^
-
-.. py:class:: MessageReplaySettings(filename: Optional[Path] = None, rate: Optional[float] = None, progress: bool = False):
-
-   `filename` is the path of the file to replay.
-
-   `rate` in Hertz at which the messages will be published. If not specified, messages will publish as fast as possible.
-
-   `progress` will use tqdm to indicate progress through the file. Tqdm must be installed.
-
-TerminateOnTimeout
-------------------
-
-End a pipeline execution when a certain amount of time has passed without receiving a message.
-
-Input/OutputStreams
-^^^^^^^^^^^^^^^^^^^
-
-.. object:: INPUT
-
-   Send messages here.
-
-Settings
-^^^^^^^^
-
-.. py:class:: TerminateOnTimeoutSettings(time: float = 2.0, poll_rate: float = 4.0)
-
-   `time` in seconds after which the pipeline will be terminated if no messages have been received
-
-   `poll_rate`
-
-
-TerminateOnTotal
-----------------
-
-End a pipeline execution once a certain number of messages have been received.
-
-Input/OutputStreams
-^^^^^^^^^^^^^^^^^^^
-
-.. object:: INPUT_MESSAGE
-
-   `Type:` ``InputStream(Any)``
-
-   Send messages here.
-
-.. object:: INPUT_TOTAL
-
-   `Type:` ``InputStream(int)``
-
-   Change the total number of messages to terminate after. If this number has already been reached, termination will occur immediately.
-
-Settings
-^^^^^^^^
-
-.. py:class:: TerminateOnTotalSettings(total: int = None)
-
-   `total` represents the total number of messages to terminate after
+.. automodule:: ezmsg.util.terminate
+   :show-inheritance:
+   :members:

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/affinetransform.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/affinetransform.py
@@ -15,6 +15,18 @@ def affine_transform(
     axis: Optional[str] = None,
     right_multiply: bool = True,
 ) -> Generator[AxisArray, AxisArray, None]:
+    """
+    Perform affine transformations on streaming data.
+
+    Args:
+        weights: An array of weights or a path to a file with weights compatible with np.loadtxt.
+        axis: The name of the axis to apply the transformation to. Defaults to the leading (0th) axis in the array.
+        right_multiply: Set False to tranpose the weights before applying.
+
+    Returns:
+        A primed generator object that yields an :obj:`AxisArray` object for every
+        :obj:`AxisArray` it receives via `send`.
+    """
     axis_arr_in = AxisArray(np.array([]), dims=[""])
     axis_arr_out = AxisArray(np.array([]), dims=[""])
 
@@ -53,12 +65,17 @@ def affine_transform(
 
 
 class AffineTransformSettings(ez.Settings):
+    """
+    Settings for :obj:`AffineTransform`.
+    See :obj:`affine_transform` for argument details.
+    """
     weights: Union[np.ndarray, str, Path]
     axis: Optional[str] = None
     right_multiply: bool = True
 
 
 class AffineTransform(GenAxisArray):
+    """:obj:`Unit` for :obj:`affine_transform`"""
     SETTINGS: AffineTransformSettings
 
     def construct_generator(self):
@@ -73,6 +90,18 @@ class AffineTransform(GenAxisArray):
 def common_rereference(
     mode: str = "mean", axis: Optional[str] = None, include_current: bool = True
 ) -> Generator[AxisArray, AxisArray, None]:
+    """
+    Perform common average referencing (CAR) on streaming data.
+
+    Args:
+        mode: The statistical mode to apply -- either "mean" or "median"
+        axis: The name of hte axis to apply the transformation to.
+        include_current: Set False to exclude each channel from participating in the calculation of its reference.
+
+    Returns:
+        A primed generator object that yields an :obj:`AxisArray` object
+        for every :obj:`AxisArray` it receives via `send`.
+    """
     axis_arr_in = AxisArray(np.array([]), dims=[""])
     axis_arr_out = AxisArray(np.array([]), dims=[""])
 
@@ -108,12 +137,19 @@ def common_rereference(
 
 
 class CommonRereferenceSettings(ez.Settings):
+    """
+    Settings for :obj:`CommonRereference`
+    See :obj:`common_rereference` for argument details.
+    """
     mode: str = "mean"
     axis: Optional[str] = None
     include_current: bool = True
 
 
 class CommonRereference(GenAxisArray):
+    """
+    :obj:`Unit` for :obj:`common_rereference`.
+    """
     SETTINGS: CommonRereferenceSettings
 
     def construct_generator(self):

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/aggregate.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/aggregate.py
@@ -9,6 +9,7 @@ from ezmsg.sigproc.spectral import OptionsEnum
 
 
 class AggregationFunction(OptionsEnum):
+    """Enum for aggregation functions available to be used in :obj:`ranged_aggregate` operation."""
     NONE = "None (all)"
     MAX = "max"
     MIN = "min"
@@ -43,6 +44,18 @@ def ranged_aggregate(
     bands: typing.Optional[typing.List[typing.Tuple[float, float]]] = None,
     operation: AggregationFunction = AggregationFunction.MEAN
 ):
+    """
+    Apply an aggregation operation over one or more bands.
+
+    Args:
+        axis: The name of the axis along which to apply the bands.
+        bands: [(band1_min, band1_max), (band2_min, band2_max), ...]
+            If not set then this acts as a passthrough node.
+        operation: :obj:`AggregationFunction` to apply to each band.
+
+    Returns:
+        A primed generator object ready to yield an AxisArray for each .send(axis_array)
+    """
     axis_arr_in = AxisArray(np.array([]), dims=[""])
     axis_arr_out = AxisArray(np.array([]), dims=[""])
 
@@ -87,12 +100,19 @@ def ranged_aggregate(
 
 
 class RangedAggregateSettings(ez.Settings):
+    """
+    Settings for ``RangedAggregate``.
+    See :obj:`ranged_aggregate` for details.
+    """
     axis: typing.Optional[str] = None
     bands: typing.Optional[typing.List[typing.Tuple[float, float]]] = None
     operation: AggregationFunction = AggregationFunction.MEAN
 
 
 class RangedAggregate(GenAxisArray):
+    """
+    Unit for :obj:`ranged_aggregate`
+    """
     SETTINGS: RangedAggregateSettings
 
     def construct_generator(self):

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/bandpower.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/bandpower.py
@@ -15,6 +15,16 @@ def bandpower(
     spectrogram_settings: SpectrogramSettings,
     bands: typing.Optional[typing.List[typing.Tuple[float, float]]] = [(17, 30), (70, 170)]
 ) -> typing.Generator[AxisArray, AxisArray, None]:
+    """
+    Calculate the average spectral power in each band.
+
+    Args:
+        spectrogram_settings: Settings for spectrogram calculation.
+        bands: (min, max) tuples of band limits in Hz.
+
+    Returns:
+        A primed generator object ready to yield an AxisArray for each .send(axis_array)
+    """
     axis_arr_in = AxisArray(np.array([]), dims=[""])
     axis_arr_out = AxisArray(np.array([]), dims=[""])
 
@@ -38,12 +48,17 @@ def bandpower(
 
 
 class BandPowerSettings(ez.Settings):
+    """
+    Settings for ``BandPower``.
+    See :obj:`bandpower` for details.
+    """
     spectrogram_settings: SpectrogramSettings = field(default_factory=SpectrogramSettings)
     bands: typing.Optional[typing.List[typing.Tuple[float, float]]] = (
         field(default_factory=lambda: [(17, 30), (70, 170)]))
 
 
 class BandPower(GenAxisArray):
+    """:obj:`Unit` for :obj:`bandpower`."""
     SETTINGS: BandPowerSettings
 
     def construct_generator(self):

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/decimate.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/decimate.py
@@ -9,6 +9,10 @@ from .filter import Filter, FilterCoefficients, FilterSettings
 
 
 class Decimate(ez.Collection):
+    """
+    A :obj:`Collection` chaining a :obj:`Filter` node configured as a lowpass Chebyshev filter
+    and a :obj:`Downsample` node.
+    """
     SETTINGS: DownsampleSettings
 
     INPUT_SIGNAL = ez.InputStream(AxisArray)

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/downsample.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/downsample.py
@@ -13,6 +13,24 @@ import ezmsg.core as ez
 def downsample(
         axis: Optional[str] = None, factor: int = 1
 ) -> Generator[AxisArray, AxisArray, None]:
+    """
+    Construct a generator that yields a downsampled version of the data .send() to it.
+    Downsampled data simply comprise every `factor`th sample.
+    This should only be used following appropriate lowpass filtering.
+    If your pipeline does not already have lowpass filtering then consider
+    using the :obj:`Decimate` collection instead.
+
+    Args:
+        axis: The name of the axis along which to downsample.
+        factor: Downsampling factor.
+
+    Returns:
+        A primed generator object ready to receive a `.send(axis_array)`
+        and yields the downsampled data.
+        Note that if a send chunk does not have sufficient samples to reach the
+        next downsample interval then `None` is yielded.
+
+    """
     axis_arr_in = AxisArray(np.array([]), dims=[""])
     axis_arr_out = AxisArray(np.array([]), dims=[""])
 
@@ -44,6 +62,10 @@ def downsample(
 
 
 class DownsampleSettings(ez.Settings):
+    """
+    Settings for :obj:`Downsample` node.
+    See :obj:`downsample` documentation for a description of the parameters.
+    """
     axis: Optional[str] = None
     factor: int = 1
 
@@ -54,6 +76,9 @@ class DownsampleState(ez.State):
 
 
 class Downsample(ez.Unit):
+    """
+    :obj:`Unit` for :obj:`downsample`.
+    """
     SETTINGS: DownsampleSettings
     STATE: DownsampleState
 

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/ewmfilter.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/ewmfilter.py
@@ -13,7 +13,10 @@ from typing import AsyncGenerator, Optional
 
 class EWMSettings(ez.Settings):
     axis: Optional[str] = None
-    zero_offset: bool = True  # If true, we assume zero DC offset
+    """Name of the axis to accumulate."""
+
+    zero_offset: bool = True
+    """If true, we assume zero DC offset for input data."""
 
 
 class EWMState(ez.State):
@@ -96,12 +99,24 @@ class EWM(ez.Unit):
 
 
 class EWMFilterSettings(ez.Settings):
-    history_dur: float  # previous data to accumulate for standardization
+    history_dur: float
+    """Previous data to accumulate for standardization."""
+
     axis: Optional[str] = None
-    zero_offset: bool = True  # If true, we assume zero DC offset for input data
+    """Name of the axis to accumulate."""
+
+    zero_offset: bool = True
+    """If true, we assume zero DC offset for input data."""
 
 
 class EWMFilter(ez.Collection):
+    """
+    A :obj:`Collection` that splits the input into a branch that
+    leads to :obj:`Window` which then feeds into :obj:`EWM` 's INPUT_BUFFER
+    and another branch that feeds directly into :obj:`EWM` 's INPUT_SIGNAL.
+
+    Consider :obj:`scaler` for a more efficient alternative.
+    """
     SETTINGS: EWMFilterSettings
 
     INPUT_SIGNAL = ez.InputStream(AxisArray)

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/filter.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/filter.py
@@ -12,10 +12,12 @@ import numpy.typing as npt
 from ezmsg.util.messages.axisarray import AxisArray
 from ezmsg.util.generator import consumer
 
+
 @dataclass
 class FilterCoefficients:
     b: np.ndarray = field(default_factory=lambda: np.array([1.0, 0.0]))
     a: np.ndarray = field(default_factory=lambda: np.array([1.0, 0.0]))
+
 
 def _normalize_coefs(
         coefs: typing.Union[FilterCoefficients, typing.Tuple[npt.NDArray, npt.NDArray],npt.NDArray]
@@ -31,10 +33,22 @@ def _normalize_coefs(
             coefs = (FilterCoefficients.b, FilterCoefficients.a)
     return coef_type, coefs
 
+
 @consumer
 def filtergen(
     axis: str, coefs: typing.Optional[typing.Tuple[np.ndarray]], coef_type: str
 ) -> typing.Generator[AxisArray, AxisArray, None]:
+    """
+    Construct a generic filter generator function.
+
+    Args:
+        axis: The name of the axis to operate on.
+        coefs: The pre-calculated filter coefficients.
+        coef_type: The type of filter coefficients. One of "ba" or "sos".
+
+    Returns:
+        A generator that expects .send(axis_array) and yields the filtered :obj:`AxisArray`.
+    """
     # Massage inputs
     if coefs is not None and not isinstance(coefs, tuple):
         # scipy.signal functions called with first arg `*coefs`, but sos coefs are a single ndarray.

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/scaler.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/scaler.py
@@ -28,6 +28,19 @@ def _alpha_from_tau(tau: float, dt: float) -> float:
 
 @consumer
 def scaler(time_constant: float = 1.0, axis: Optional[str] = None) -> Generator[AxisArray, AxisArray, None]:
+    """
+    Create a generator function that applies the
+    adaptive standard scaler from https://riverml.xyz/latest/api/preprocessing/AdaptiveStandardScaler/
+    This is faster than :obj:`scaler_np` for single-channel data.
+
+    Args:
+        time_constant: Decay constant `tau` in seconds.
+        axis: The name of the axis to accumulate statistics over.
+
+    Returns:
+        A primed generator object that expects `.send(axis_array)` and yields a
+        standardized, or "Z-scored" version of the input.
+    """
     from river import preprocessing
     axis_arr_in = AxisArray(np.array([]), dims=[""])
     axis_arr_out = AxisArray(np.array([]), dims=[""])
@@ -62,8 +75,18 @@ def scaler(time_constant: float = 1.0, axis: Optional[str] = None) -> Generator[
 
 @consumer
 def scaler_np(time_constant: float = 1.0, axis: Optional[str] = None) -> Generator[AxisArray, AxisArray, None]:
-    # The only dependency is numpy.
-    # This is faster for multi-channel data but slower for single-channel data.
+    """
+    Create a generator function that applies an adaptive standard scaler.
+    This is faster than :obj:`scaler` for multichannel data.
+
+    Args:
+        time_constant: Decay constant `tau` in seconds.
+        axis: The name of the axis to accumulate statistics over.
+
+    Returns:
+        A primed generator object that expects `.send(axis_array)` and yields a
+        standardized, or "Z-scored" version of the input.
+    """
     axis_arr_in = AxisArray(np.array([]), dims=[""])
     axis_arr_out = AxisArray(np.array([]), dims=[""])
     means = vars_means = vars_sq_means = None
@@ -113,11 +136,16 @@ def scaler_np(time_constant: float = 1.0, axis: Optional[str] = None) -> Generat
 
 
 class AdaptiveStandardScalerSettings(ez.Settings):
+    """
+    Settings for :obj:`AdaptiveStandardScaler`.
+    See :obj:`scaler_np` for a description of the parameters.
+    """
     time_constant: float = 1.0
     axis: Optional[str] = None
 
 
 class AdaptiveStandardScaler(GenAxisArray):
+    """Unit for :obj:`scaler_np`"""
     SETTINGS: AdaptiveStandardScalerSettings
 
     def construct_generator(self):

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/slicer.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/slicer.py
@@ -15,19 +15,20 @@ Slicer:Select a subset of data along a particular axis.
 def parse_slice(s: str) -> typing.Tuple[typing.Union[slice, int], ...]:
     """
     Parses a string representation of a slice and returns a tuple of slice objects.
-    * "" -> slice(None, None, None)  (take all)
-    * ":" -> slice(None, None, None)
-    * '"none"` (case-insensitive) -> slice(None, None, None)
-    * "{start}:{stop}" or {start}:{stop}:{step} -> slice(start, stop, step)
-    * "5" (or any integer) -> (5,). Take only that item.
+
+    - "" -> slice(None, None, None)  (take all)
+    - ":" -> slice(None, None, None)
+    - '"none"` (case-insensitive) -> slice(None, None, None)
+    - "{start}:{stop}" or {start}:{stop}:{step} -> slice(start, stop, step)
+    - "5" (or any integer) -> (5,). Take only that item.
         applying this to a ndarray or AxisArray will drop the dimension.
-    * A comma-separated list of the above -> a tuple of slices | ints
+    - A comma-separated list of the above -> a tuple of slices | ints
 
     Args:
-        s (str): The string representation of the slice.
+        s: The string representation of the slice.
 
     Returns:
-        tuple[slice | int, ...]: A tuple of slice objects and/or ints.
+        A tuple of slice objects and/or ints.
     """
     if s.lower() in ["", ":", "none"]:
         return (slice(None),)

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/spectrogram.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/spectrogram.py
@@ -21,6 +21,24 @@ def spectrogram(
     transform: SpectralTransform = SpectralTransform.REL_DB,
     output: SpectralOutput = SpectralOutput.POSITIVE
 ) -> typing.Generator[typing.Optional[AxisArray], AxisArray, None]:
+    """
+    Calculate a spectrogram on streaming data.
+
+    Chains :obj:`ezmsg.sigproc.window.windowing` to apply a moving window on the data,
+    :obj:`ezmsg.sigproc.spectrum.spectrum` to calculate spectra for each window,
+    and finally :obj:`ezmsg.util.messages.modify.modify_axis` to convert the win axis back to time axis.
+
+    Args:
+        window_dur: See :obj:`ezmsg.sigproc.window.windowing`
+        window_shift: See :obj:`ezmsg.sigproc.window.windowing`
+        window: See :obj:`ezmsg.sigproc.spectrum.spectrum`
+        transform: See :obj:`ezmsg.sigproc.spectrum.spectrum`
+        output: See :obj:`ezmsg.sigproc.spectrum.spectrum`
+
+    Returns:
+        A primed generator object that expects `.send(axis_array)` of continuous data
+        and yields an AxisArray of time-frequency power values.
+    """
 
     # We cannot use `compose` because `windowing` returns a list of axisarray objects,
     #  even though the length is always exactly 1 for the settings used here.
@@ -47,6 +65,10 @@ def spectrogram(
 
 
 class SpectrogramSettings(ez.Settings):
+    """
+    Settings for :obj:`Spectrogram`.
+    See :obj:`spectrogram` for a description of the parameters.
+    """
     window_dur: typing.Optional[float] = None  # window duration in seconds
     window_shift: typing.Optional[float] = None  # window step in seconds. If None, window_shift == window_dur
     # See SpectrumSettings for details of following settings:
@@ -56,6 +78,9 @@ class SpectrogramSettings(ez.Settings):
 
 
 class Spectrogram(GenAxisArray):
+    """
+    Unit for :obj:`spectrogram`.
+    """
     SETTINGS: SpectrogramSettings
 
     def construct_generator(self):

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/spectrum.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/spectrum.py
@@ -15,11 +15,21 @@ class OptionsEnum(enum.Enum):
 
 
 class WindowFunction(OptionsEnum):
+    """Windowing function prior to calculating spectrum. """
     NONE = "None (Rectangular)"
+    """None."""
+
     HAMMING = "Hamming"
+    """:obj:`numpy.hamming`"""
+
     HANNING = "Hanning"
+    """:obj:`numpy.hanning`"""
+
     BARTLETT = "Bartlett"
+    """:obj:`numpy.bartlett`"""
+
     BLACKMAN = "Blackman"
+    """:obj:`numpy.blackman`"""
 
 
 WINDOWS = {
@@ -32,6 +42,7 @@ WINDOWS = {
 
 
 class SpectralTransform(OptionsEnum):
+    """Additional transformation functions to apply to the spectral result."""
     RAW_COMPLEX = "Complex FFT Output"
     REAL = "Real Component of FFT"
     IMAG = "Imaginary Component of FFT"
@@ -40,6 +51,7 @@ class SpectralTransform(OptionsEnum):
 
 
 class SpectralOutput(OptionsEnum):
+    """The expected spectral contents."""
     FULL = "Full Spectrum"
     POSITIVE = "Positive Frequencies"
     NEGATIVE = "Negative Frequencies"
@@ -53,6 +65,20 @@ def spectrum(
     transform: SpectralTransform = SpectralTransform.REL_DB,
     output: SpectralOutput = SpectralOutput.POSITIVE
 ) -> Generator[AxisArray, AxisArray, None]:
+    """
+    Calculate a spectrum on a data slice.
+
+    Args:
+        axis: The name of the axis on which to calculate the spectrum.
+        out_axis: The name of the new axis. Defaults to "freq".
+        window: The :obj:`WindowFunction` to apply to the data slice prior to calculating the spectrum.
+        transform: The :obj:`SpectralTransform` to apply to the spectral magnitude.
+        output: The :obj:`SpectralOutput` format.
+
+    Returns:
+        A primed generator object that expects `.send(axis_array)` of continuous data
+        and yields an AxisArray of spectral magnitudes or powers.
+    """
 
     # State variables
     axis_arr_in = AxisArray(np.array([]), dims=[""])
@@ -120,6 +146,10 @@ def spectrum(
 
 
 class SpectrumSettings(ez.Settings):
+    """
+    Settings for :obj:`Spectrum.
+    See :obj:`spectrum` for a description of the parameters.
+    """
     axis: Optional[str] = None
     # n: Optional[int] = None # n parameter for fft
     out_axis: Optional[str] = "freq"  # If none; don't change dim name
@@ -134,6 +164,7 @@ class SpectrumState(ez.State):
 
 
 class Spectrum(GenAxisArray):
+    """Unit for :obj:`spectrum`"""
     SETTINGS: SpectrumSettings
     STATE: SpectrumState
 

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/window.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/window.py
@@ -19,24 +19,28 @@ def windowing(
     zero_pad_until: str = "input"
 ) -> Generator[AxisArray, List[AxisArray], None]:
     """
-    Window function that generates windows of data from an input `AxisArray`.
-    :param axis: The axis along which to segment windows.
-        If None, defaults to the first dimension of the first seen AxisArray.
-    :param newaxis: Optional new axis for the output. If None, no new axes will be added.
-        If a string, windows will be stacked in a new axis with key `newaxis`, immediately preceding the windowed axis.
-    :param window_dur: The duration of the window in seconds.
-        If None, the function acts as a passthrough and all other parameters are ignored.
-    :param window_shift: The shift of the window in seconds.
-        If None (default), windowing operates in "1:1 mode", where each input yields exactly one most-recent window.
-    :param zero_pad_until: Determines how the function initializes the buffer.
-        Can be one of "input" (default), "full", "shift", or "none". If `window_shift` is None then this field is
-        ignored and "input" is always used.
-        "input" (default) initializes the buffer with the input then prepends with zeros to the window size.
-            The first input will always yield at least one output.
-        "shift" fills the buffer until `window_shift`.
-            No outputs will be yielded until at least `window_shift` data has been seen.
-        "none" does not pad the buffer. No outputs will be yielded until at least `window_dur` data has been seen.
-    :return:
+    Construct a generator that yields windows of data from an input :obj:`AxisArray`.
+
+    Args:
+        axis: The axis along which to segment windows.
+            If None, defaults to the first dimension of the first seen AxisArray.
+        newaxis: Optional new axis for the output. If None, no new axes will be added.
+            If a string, windows will be stacked in a new axis with key `newaxis`, immediately preceding the windowed axis.
+        window_dur: The duration of the window in seconds.
+            If None, the function acts as a passthrough and all other parameters are ignored.
+        window_shift: The shift of the window in seconds.
+            If None (default), windowing operates in "1:1 mode", where each input yields exactly one most-recent window.
+        zero_pad_until: Determines how the function initializes the buffer.
+            Can be one of "input" (default), "full", "shift", or "none". If `window_shift` is None then this field is
+            ignored and "input" is always used.
+
+            - "input" (default) initializes the buffer with the input then prepends with zeros to the window size.
+              The first input will always yield at least one output.
+            - "shift" fills the buffer until `window_shift`.
+              No outputs will be yielded until at least `window_shift` data has been seen.
+            - "none" does not pad the buffer. No outputs will be yielded until at least `window_dur` data has been seen.
+
+    Returns:
         A (primed) generator that accepts .send(an AxisArray object) and yields a list of windowed
         AxisArray objects. The list will always be length-1 if `newaxis` is not None or `window_shift` is None.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ pytest-cov = "*"
 numpy = "^1.24.2"
 flake8 = "*"
 
+
+[tool.poetry.group.docs.dependencies]
+sphinx = "<7.2"
+sphinx-rtd-theme = "^2.0.0"
+
 [tool.poetry.extras]
 sigproc = ["ezmsg-sigproc"]
 websocket = ["ezmsg-websocket"]

--- a/src/ezmsg/core/backend.py
+++ b/src/ezmsg/core/backend.py
@@ -167,6 +167,26 @@ def run(
     force_single_process: bool = False,
     **components_kwargs: Component,
 ) -> None:
+    """
+    Begin execution of a set of ``Components``.
+
+    `The old method` run_system() `has been deprecated and uses` run() `instead.`
+
+    :param components: represents the nodes in the directed acyclic graph. It is a dictionary which contains the
+        ``Components`` to be run mapped to string names. On initialization, ``ezmsg`` will call ``initialize()``
+        for each ``Unit`` and ``configure()`` for each ``Collection``, if defined.
+    :param root_name:
+    :param connections: represents the edges is a ``NetworkDefinition`` which connects
+        ``OutputStreams`` to ``InputStreams``. On initialization, ``ezmsg`` will create a directed acyclic graph
+        using the contents of this parameter.
+    :param process_components: a list of ``Components`` which should live in their own process.
+    :param backend_process: is currently under development.
+    :param graph_address: the hostname and port of the graph server which ``ezmsg`` should connect to.
+        If not defined, ``ezmsg`` will start a new graph server at 127.0.0.1:25978.
+    :param force_single_process: run all ``Components`` in one process.
+        This is necessary when running ``ezmsg`` in a notebook.
+    :param components_kwargs:
+    """
     # FIXME: This function is the last major re-implementation needed to make this
     # codebase more maintainable.
     graph_service = GraphService(graph_address)

--- a/src/ezmsg/core/backend.py
+++ b/src/ezmsg/core/backend.py
@@ -168,24 +168,25 @@ def run(
     **components_kwargs: Component,
 ) -> None:
     """
-    Begin execution of a set of ``Components``.
+    Begin execution of a set of :obj:`Component` s.
 
-    `The old method` run_system() `has been deprecated and uses` run() `instead.`
+    `The old method` :obj:`run_system` `has been deprecated and uses` ``run()`` `instead.`
 
-    :param components: represents the nodes in the directed acyclic graph. It is a dictionary which contains the
-        ``Components`` to be run mapped to string names. On initialization, ``ezmsg`` will call ``initialize()``
-        for each ``Unit`` and ``configure()`` for each ``Collection``, if defined.
-    :param root_name:
-    :param connections: represents the edges is a ``NetworkDefinition`` which connects
-        ``OutputStreams`` to ``InputStreams``. On initialization, ``ezmsg`` will create a directed acyclic graph
-        using the contents of this parameter.
-    :param process_components: a list of ``Components`` which should live in their own process.
-    :param backend_process: is currently under development.
-    :param graph_address: the hostname and port of the graph server which ``ezmsg`` should connect to.
-        If not defined, ``ezmsg`` will start a new graph server at 127.0.0.1:25978.
-    :param force_single_process: run all ``Components`` in one process.
-        This is necessary when running ``ezmsg`` in a notebook.
-    :param components_kwargs:
+    Args:
+        components: represents the nodes in the directed acyclic graph. It is a dictionary which contains the
+            ``Components`` to be run mapped to string names. On initialization, ``ezmsg`` will call ``initialize()``
+            for each :obj:`Unit` and ``configure()`` for each :obj:`Collection`, if defined.
+        root_name:
+        connections: represents the edges is a ``NetworkDefinition`` which connects
+            ``OutputStreams`` to ``InputStreams``. On initialization, ``ezmsg`` will create a directed acyclic graph
+            using the contents of this parameter.
+        process_components: a list of ``Components`` which should live in their own process.
+        backend_process: is currently under development.
+        graph_address: the hostname and port of the graph server which ``ezmsg`` should connect to.
+            If not defined, ``ezmsg`` will start a new graph server at 127.0.0.1:25978.
+        force_single_process: run all ``Components`` in one process.
+            This is necessary when running ``ezmsg`` in a notebook.
+        components_kwargs:
     """
     # FIXME: This function is the last major re-implementation needed to make this
     # codebase more maintainable.

--- a/src/ezmsg/core/backendprocess.py
+++ b/src/ezmsg/core/backendprocess.py
@@ -43,7 +43,7 @@ logger = logging.getLogger("ezmsg")
 class Complete(Exception):
     """
     A type of ``Exception`` which signals to ``ezmsg`` that the function can be shut down gracefully.
-    If all functions in all ``Units`` raise ``Complete``, the entire pipeline will terminate execution.
+    If all functions in all :obj:`Units` raise ``Complete``, the entire pipeline will terminate execution.
     """
     pass
 

--- a/src/ezmsg/core/backendprocess.py
+++ b/src/ezmsg/core/backendprocess.py
@@ -41,10 +41,17 @@ logger = logging.getLogger("ezmsg")
 
 
 class Complete(Exception):
+    """
+    A type of ``Exception`` which signals to ``ezmsg`` that the function can be shut down gracefully.
+    If all functions in all ``Units`` raise ``Complete``, the entire pipeline will terminate execution.
+    """
     pass
 
 
 class NormalTermination(Exception):
+    """
+    A type of ``Exception`` which signals to ``ezmsg`` that the pipeline can be shut down gracefully.
+    """
     pass
 
 

--- a/src/ezmsg/core/collection.py
+++ b/src/ezmsg/core/collection.py
@@ -34,7 +34,9 @@ class CollectionMeta(ComponentMeta):
 
 
 class Collection(Component, metaclass=CollectionMeta):
-    """Collections can contain subunits and connect them together"""
+    """
+    Connects ``Units`` together by defining a graph which connects ``OutputStreams`` to ``InputStreams``.
+    """
 
     def __init__(self, *args, settings: typing.Optional[Settings] = None, **kwargs):
         super(Collection, self).__init__(*args, settings=settings, **kwargs)
@@ -44,11 +46,23 @@ class Collection(Component, metaclass=CollectionMeta):
             setattr(self, comp_name, comp)
 
     def configure(self) -> None:
-        """This is where to percolate apply_settings to subnodes"""
+        """
+        A lifecycle hook that runs when the ``Collection`` is instantiated.
+        This is the best place to call ``Unit.apply_settings()`` on each member ``Unit`` of the ``Collection``.
+        """
         ...
 
     def network(self) -> NetworkDefinition:
+        """
+        Override this method and have the definition return a ``NetworkDefinition`` which defines how
+        ``InputStreams`` and ``OutputStreams`` from member ``Units`` will be connected.
+        """
         return ()
 
     def process_components(self) -> typing.Collection[Component]:
+        """
+        Override this method and have the definition return a tuple which contains ``Units`` and ``Collections``
+        which should run in their own processes.
+        :return: the ``Collection``.
+        """
         return (self,)

--- a/src/ezmsg/core/collection.py
+++ b/src/ezmsg/core/collection.py
@@ -35,7 +35,7 @@ class CollectionMeta(ComponentMeta):
 
 class Collection(Component, metaclass=CollectionMeta):
     """
-    Connects ``Units`` together by defining a graph which connects ``OutputStreams`` to ``InputStreams``.
+    Connects :obj:`Unit` s together by defining a graph which connects :obj:`OutputStream` s to :obj:`InputStream` s.
     """
 
     def __init__(self, *args, settings: typing.Optional[Settings] = None, **kwargs):
@@ -47,22 +47,23 @@ class Collection(Component, metaclass=CollectionMeta):
 
     def configure(self) -> None:
         """
-        A lifecycle hook that runs when the ``Collection`` is instantiated.
-        This is the best place to call ``Unit.apply_settings()`` on each member ``Unit`` of the ``Collection``.
+        A lifecycle hook that runs when the :obj:`Collection` is instantiated.
+        This is the best place to call ``Unit.apply_settings()`` on each member :obj:`Unit` of the :obj:`Collection`.
         """
         ...
 
     def network(self) -> NetworkDefinition:
         """
-        Override this method and have the definition return a ``NetworkDefinition`` which defines how
-        ``InputStreams`` and ``OutputStreams`` from member ``Units`` will be connected.
+        Override this method and have the definition return a :obj:`NetworkDefinition` which defines how
+        :obj:`InputStream` and :obj:`OutputStream` from member :obj:`Unit` s will be connected.
         """
         return ()
 
     def process_components(self) -> typing.Collection[Component]:
         """
-        Override this method and have the definition return a tuple which contains ``Units`` and ``Collections``
+        Override this method and have the definition return a tuple which contains :obj:`Unit` and :obj:`Collection`
         which should run in their own processes.
-        :return: the ``Collection``.
+
+        Return: the :obj:`Collection`.
         """
         return (self,)

--- a/src/ezmsg/core/component.py
+++ b/src/ezmsg/core/component.py
@@ -73,7 +73,7 @@ class ComponentMeta(ABCMeta):
 
 class Component(Addressable, metaclass=ComponentMeta):
     """
-    Metaclass which ``Units`` and ``Collections`` inherit from.
+    Metaclass which :obj:`Unit` and :obj:`Collection` inherit from.
     """
 
     SETTINGS: Settings
@@ -139,7 +139,8 @@ class Component(Addressable, metaclass=ComponentMeta):
         """
         Update the ``Component``‘s ``Settings`` object.
 
-        :param settings: An instance of the class-specific ``Settings``.
+        Args:
+            settings: An instance of the class-specific ``Settings``.
 
         """
         self.SETTINGS = settings

--- a/src/ezmsg/core/component.py
+++ b/src/ezmsg/core/component.py
@@ -72,6 +72,10 @@ class ComponentMeta(ABCMeta):
 
 
 class Component(Addressable, metaclass=ComponentMeta):
+    """
+    Metaclass which ``Units`` and ``Collections`` inherit from.
+    """
+
     SETTINGS: Settings
     STATE: State
 
@@ -132,6 +136,12 @@ class Component(Addressable, metaclass=ComponentMeta):
                 )
 
     def apply_settings(self, settings: Settings) -> None:
+        """
+        Update the ``Component``‘s ``Settings`` object.
+
+        :param settings: An instance of the class-specific ``Settings``.
+
+        """
         self.SETTINGS = settings
         self._settings_applied = True
 

--- a/src/ezmsg/core/settings.py
+++ b/src/ezmsg/core/settings.py
@@ -28,4 +28,38 @@ class SettingsMeta(ABCMeta):
 
 
 class Settings(ABC, metaclass=SettingsMeta):
+    """
+    To pass parameters into a ``Component``, inherit from ``Settings``.
+
+    .. code-block:: python
+
+       class YourSettings(Settings):
+          setting1: int
+          setting2: float
+
+    To use, declare the ``Settings`` object for a ``Component`` as a member variable called (all-caps!) ``SETTINGS``. ``ezmsg`` will monitor the variable called ``SETTINGS`` in the background, so it is important to name it correctly.
+
+    .. code-block:: python
+
+       class YourUnit(Unit):
+
+          SETTINGS: YourSettings
+
+    A ``Unit`` can accept a ``Settings`` object as a parameter on instantiation.
+
+    .. code-block:: python
+
+       class YourCollection(Collection):
+
+          YOUR_UNIT = YourUnit(
+             YourSettings(
+                setting1: int,
+                setting2: float
+             )
+          )
+
+    .. note::
+       ``Settings`` uses type hints to define member variables, but does not enforce type checking.
+
+    """
     ...

--- a/src/ezmsg/core/settings.py
+++ b/src/ezmsg/core/settings.py
@@ -29,7 +29,7 @@ class SettingsMeta(ABCMeta):
 
 class Settings(ABC, metaclass=SettingsMeta):
     """
-    To pass parameters into a ``Component``, inherit from ``Settings``.
+    To pass parameters into a :obj:`Component`, inherit from ``Settings``.
 
     .. code-block:: python
 

--- a/src/ezmsg/core/state.py
+++ b/src/ezmsg/core/state.py
@@ -24,6 +24,33 @@ class StateMeta(ABCMeta):
 class State(ABC, metaclass=StateMeta):
     """
     States are mutable dataclasses that are instantiated by the Unit in its home process.
-    """
 
+    To track a mutable state for a ``Component``, inherit from ``State``.
+
+    .. code-block:: python
+
+       class YourState(State):
+          state1: int
+          state2: float
+
+    To use, declare the ``State`` object for a ``Component`` as a member variable called (all-caps!) ``STATE``.
+    ``ezmsg`` will monitor the variable called ``STATE`` in the background, so it is important to name it correctly.
+
+    Member functions can then access and mutate ``STATE`` as needed during function execution.
+    It is recommended to initialize state values inside the ``initialize()`` or ``configure()`` lifecycle hooks if
+    defaults are not defined.
+
+    .. code-block:: python
+
+       class YourUnit(Unit):
+
+          STATE: YourState
+
+          def initialize(self):
+             this.STATE.state1 = 0
+             this.STATE.state2 = 0.0
+
+    .. note::
+       ``State`` uses type hints to define member variables, but does not enforce type checking.
+    """
     ...

--- a/src/ezmsg/core/stream.py
+++ b/src/ezmsg/core/stream.py
@@ -5,6 +5,10 @@ from .addressable import Addressable
 
 
 class Stream(Addressable):
+    """
+
+    """
+
     msg_type: Type
 
     def __init__(self, msg_type: Type):
@@ -17,11 +21,17 @@ class Stream(Addressable):
 
 
 class InputStream(Stream):
+    """
+    Can be added to any ``Component`` as a member variable. Methods may subscribe to it.
+    """
     def __repr__(self) -> str:
         return f"Input{super().__repr__()}()"
 
 
 class OutputStream(Stream):
+    """
+    Can be added to any ``Component`` as a member variable. Methods may publish to it.
+    """
     host: Optional[str]
     port: Optional[int]
     num_buffers: int

--- a/src/ezmsg/core/unit.py
+++ b/src/ezmsg/core/unit.py
@@ -110,7 +110,7 @@ class Unit(Component, metaclass=UnitMeta):
 def publisher(stream: OutputStream):
     """
     A decorator for a method that publishes to a stream in the task/messaging thread.
-    An async function will yield messages on the designated ``OutputStream``.
+    An async function will yield messages on the designated :obj:`OutputStream`.
 
     .. code-block:: python
 
@@ -141,7 +141,7 @@ def publisher(stream: OutputStream):
 def subscriber(stream: InputStream, zero_copy: bool = False):
     """
     A decorator for a method that subscribes to a stream in the task/messaging thread.
-    An async function will run once per message received from the ``InputStream`` it subscribes to.
+    An async function will run once per message received from the :obj:`InputStream` it subscribes to.
 
     Example:
 
@@ -172,8 +172,8 @@ def subscriber(stream: InputStream, zero_copy: bool = False):
 
 def main(func: Callable):
     """
-    A decorator which designates this function to run as the main thread for this ``Unit``.
-    A ``Unit`` may only have one of these.
+    A decorator which designates this function to run as the main thread for this :obj:`Unit`.
+    A :obj:`Unit` may only have one of these.
     """
     setattr(func, MAIN_ATTR, True)
     return func
@@ -200,7 +200,7 @@ def timeit(func: Callable):
 
 def thread(func: Callable):
     """
-    A decorator which designates this function to run as a background thread for this ``Unit``.
+    A decorator which designates this function to run as a background thread for this `:obj:`Unit`.
     """
     setattr(func, THREAD_ATTR, True)
     return func

--- a/src/ezmsg/util/debuglog.py
+++ b/src/ezmsg/util/debuglog.py
@@ -4,15 +4,31 @@ from typing import AsyncGenerator, Optional, Any
 
 
 class DebugLogSettings(ez.Settings):
-    name: str = "DEBUG"  # Useful name for logger
-    max_length: Optional[int] = 400  # No limit if `None``
+    """
+    ``Settings`` class associated with ``DebugLog``
+
+    Args:
+        name: Useful name for the logger. The name is included in the logstring so that if multiple DebugLogs
+            are used in one pipeline, their messages can be differentiated.
+        max_length: Sets a maximum number of chars which will be printed from the message.
+            If the message is longer, the log message will be truncated.
+    """
+    name: str = "DEBUG"
+    max_length: Optional[int] = 400
 
 
 class DebugLog(ez.Unit):
+    """
+    Logs messages that pass through.
+    """
+
     SETTINGS: DebugLogSettings
 
     INPUT = ez.InputStream(Any)
+    """Send messages to log here."""
+
     OUTPUT = ez.OutputStream(Any)
+    """Send messages back out to continue through the graph."""
 
     @ez.subscriber(INPUT, zero_copy=True)
     @ez.publisher(OUTPUT)

--- a/src/ezmsg/util/debuglog.py
+++ b/src/ezmsg/util/debuglog.py
@@ -5,7 +5,7 @@ from typing import AsyncGenerator, Optional, Any
 
 class DebugLogSettings(ez.Settings):
     """
-    ``Settings`` class associated with ``DebugLog``
+    ``Settings`` class associated with :obj:`DebugLog`
 
     Args:
         name: Useful name for the logger. The name is included in the logstring so that if multiple DebugLogs

--- a/src/ezmsg/util/messagegate.py
+++ b/src/ezmsg/util/messagegate.py
@@ -6,14 +6,23 @@ import ezmsg.core as ez
 
 @dataclass
 class GateMessage:
+    """Send this message to ``INPUT_GATE`` to open or close the gate."""
     open: bool
 
 
 class MessageGateSettings(ez.Settings):
+    """
+    Settings for ``MessageGate`` unit.
+
+    Args:
+        start_open: sets the gate's initial state to allow messages to flow through or be discarded. ``True`` will
+            allow messages to flow through initially, ``False`` will discard messages initially.
+        default_open: sets the gate's behavior after the `default_after` number of messages have flowed through.
+            ``True`` will allow messages to flow through, ``False`` will discard messages.
+        default_after: sets the number of messages after which the `default_open` state will be applied.
+    """
     start_open: bool = False
     default_open: bool = False
-
-    # Automatically change back to default state after X messages
     default_after: typing.Optional[int] = None
 
 
@@ -23,13 +32,25 @@ class MessageGateState(ez.State):
 
 
 class MessageGate(ez.Unit):
+    """
+    Blocks ``Messages`` from continuing through the system.
+    Can be set as open, closed, open after n messages, or closed after n messages.
+    """
+
     SETTINGS: MessageGateSettings
     STATE: MessageGateState
 
     INPUT_GATE = ez.InputStream(GateMessage)
+    """
+    Stop or start message flow. If ``GateMessage.open == True``, messages will flow through.
+    If ``GateMessage.open == False``, messages will be discarded.
+    """
 
     INPUT = ez.InputStream(typing.Any)
+    """Messages which will flow through or be discarded, depending on gate status."""
+
     OUTPUT = ez.OutputStream(typing.Any)
+    """Publishes messages which flow through."""
 
     def initialize(self) -> None:
         self.STATE.gate_open = self.SETTINGS.start_open

--- a/src/ezmsg/util/messagegate.py
+++ b/src/ezmsg/util/messagegate.py
@@ -12,7 +12,7 @@ class GateMessage:
 
 class MessageGateSettings(ez.Settings):
     """
-    Settings for ``MessageGate`` unit.
+    Settings for :obj:`MessageGate` unit.
 
     Args:
         start_open: sets the gate's initial state to allow messages to flow through or be discarded. ``True`` will

--- a/src/ezmsg/util/messagelogger.py
+++ b/src/ezmsg/util/messagelogger.py
@@ -18,10 +18,10 @@ def log_object(obj: Any) -> str:
 
 class MessageLoggerSettings(ez.Settings):
     """
-    Settings for ``MessageLogger`` Unit.
+    Settings for :obj:`MessageLogger` Unit.
 
     Args:
-        output: ``pathlib.Path`` for a file where the messages will be logged.
+        output: :py:class:`pathlib.Path` for a file where the messages will be logged.
             If the file path already exists, the existing file will be truncated to 0 length.
     """
     output: Optional[Path] = None
@@ -35,7 +35,7 @@ class MessageLogger(ez.Unit):
     """
     Logs all messages it receives to a file.
     File path can be set in ``SETTINGS`` or set dynamically by passing a
-    ``pathlib.Path`` to ``INPUT_START``.
+    :py:class:`pathlib.Path` to ``INPUT_START``.
     """
 
     SETTINGS: MessageLoggerSettings
@@ -43,14 +43,14 @@ class MessageLogger(ez.Unit):
 
     INPUT_START = ez.InputStream(Path)
     """
-    Pass a ``pathlib.Path`` 
+    Pass a :py:class:`pathlib.Path` 
     to begin logging messages to that path. If the file path already exists, the existing 
     file will be truncated to 0 length. If the file is already open, nothing will happen.
     """
 
     INPUT_STOP = ez.InputStream(Path)
     """
-    Pass a ``pathlib.Path`` 
+    Pass a :py:class:`pathlib.Path` 
     to stop logging messages to that path.
     """
 

--- a/src/ezmsg/util/messagelogger.py
+++ b/src/ezmsg/util/messagelogger.py
@@ -17,6 +17,13 @@ def log_object(obj: Any) -> str:
 
 
 class MessageLoggerSettings(ez.Settings):
+    """
+    Settings for ``MessageLogger`` Unit.
+
+    Args:
+        output: ``pathlib.Path`` for a file where the messages will be logged.
+            If the file path already exists, the existing file will be truncated to 0 length.
+    """
     output: Optional[Path] = None
 
 
@@ -25,15 +32,41 @@ class MessageLoggerState(ez.State):
 
 
 class MessageLogger(ez.Unit):
+    """
+    Logs all messages it receives to a file.
+    File path can be set in ``SETTINGS`` or set dynamically by passing a
+    ``pathlib.Path`` to ``INPUT_START``.
+    """
+
     SETTINGS: MessageLoggerSettings
     STATE: MessageLoggerState
 
     INPUT_START = ez.InputStream(Path)
+    """
+    Pass a ``pathlib.Path`` 
+    to begin logging messages to that path. If the file path already exists, the existing 
+    file will be truncated to 0 length. If the file is already open, nothing will happen.
+    """
+
     INPUT_STOP = ez.InputStream(Path)
+    """
+    Pass a ``pathlib.Path`` 
+    to stop logging messages to that path.
+    """
+
     INPUT_MESSAGE = ez.InputStream(Any)
+    """Pass a piece of data to log it to every open file which the ``MessageLogger`` is using."""
+
     OUTPUT_MESSAGE = ez.OutputStream(Any)
+    """Messages which are sent to ``INPUT_MESSAGE`` will pass through and be published on ``OUTPUT_MESSAGE``."""
+
     OUTPUT_START = ez.OutputStream(Path)
+    """If a file passed to ``INPUT_START`` is successfully opened, its path will be published to
+    ``OUTPUT_START``, otherwise ``None``."""
+
     OUTPUT_STOP = ez.OutputStream(Path)
+    """If a file passed to ``INPUT_STOP`` is successfully closed, its path will be published to
+    ``OUTPUT_STOP``, otherwise ``None``."""
 
     def open_file(self, filepath: Path) -> Optional[Path]:
         """Returns file path if file successfully opened, otherwise None"""

--- a/src/ezmsg/util/messagequeue.py
+++ b/src/ezmsg/util/messagequeue.py
@@ -5,6 +5,13 @@ from ezmsg.util.rate import Rate
 
 
 class MessageQueueSettings(ez.Settings):
+    """
+    Settings for MessageQueue class.
+
+    Args:
+        maxsize: The maximum number of items which the queue will hold.
+        leaky: Whether the queue will drop new messages when it reaches its maxsize, or whether it will wait for space to open for them.
+    """
     maxsize: int = 0
     leaky: bool = False
     log_above_n: Optional[int] = None
@@ -17,11 +24,18 @@ class MessageQueueState(ez.State):
 
 
 class MessageQueue(ez.Unit):
+    """
+    Place between two other ``Units`` to induce backpressure.
+    """
+
     SETTINGS: MessageQueueSettings
     STATE: MessageQueueState
 
     INPUT = ez.InputStream(Any)
+    """Send messages to queue here."""
+
     OUTPUT = ez.OutputStream(Any)
+    """Subscribe to pull messages out of the queue."""
 
     def initialize(self):
         self.STATE.leaky = self.SETTINGS.leaky

--- a/src/ezmsg/util/messagequeue.py
+++ b/src/ezmsg/util/messagequeue.py
@@ -6,7 +6,7 @@ from ezmsg.util.rate import Rate
 
 class MessageQueueSettings(ez.Settings):
     """
-    Settings for MessageQueue class.
+    Settings for :obj:`MessageQueue` class.
 
     Args:
         maxsize: The maximum number of items which the queue will hold.

--- a/src/ezmsg/util/messagereplay.py
+++ b/src/ezmsg/util/messagereplay.py
@@ -45,10 +45,10 @@ class FileReplayMessage:
 
 class MessageReplaySettings(ez.Settings, FileReplayMessage):
     """
-    Settings for ``MesssageReplay`` Unit.
+    Settings for :obj:`MesssageReplay` Unit.
 
     Args:
-        progress: will use tqdm to indicate progress through the file. Tqdm must be installed.
+        progress: will use tqdm to indicate progress through the file. tqdm must be installed.
     """
     progress: bool = False
 
@@ -61,7 +61,7 @@ class MessageReplayState(ez.State):
 
 class MessageReplay(ez.Unit):
     """
-    Stream messages from files created by ``MessageLogger``.
+    Stream messages from files created by :obj:`MessageLogger`.
     Stores a queue of files to stream and streams from them in order.
     """
 

--- a/src/ezmsg/util/messagereplay.py
+++ b/src/ezmsg/util/messagereplay.py
@@ -13,6 +13,15 @@ from .messagecodec import MessageDecoder, LogStart
 
 @dataclass
 class ReplayStatusMessage:
+    """
+    Message which gives the status of a file replay.
+
+    Args:
+        filename: The name of the file currently being replayed.
+        idx: The line number of the message that was just published.
+        total: Number of messages in the file.
+        done: Whether the file has finished replaying.
+    """
     filename: Path
     idx: int
     total: int
@@ -21,13 +30,26 @@ class ReplayStatusMessage:
 
 @dataclass
 class FileReplayMessage:
-    filename: typing.Optional[Path] = None
+    """
+    Add a file to the queue.
 
-    # 0 = realtime (if timestamps in file), None = as fast as possible
+    Args:
+        filename: The path of the file to replay.
+        rate: in Hertz at which the messages will be published.
+            0 = realtime (if timestamps in file)
+            If not specified, messages will publish as fast as possible.
+    """
+    filename: typing.Optional[Path] = None
     rate: typing.Optional[float] = None  # Hz
 
 
 class MessageReplaySettings(ez.Settings, FileReplayMessage):
+    """
+    Settings for ``MesssageReplay`` Unit.
+
+    Args:
+        progress: will use tqdm to indicate progress through the file. Tqdm must be installed.
+    """
     progress: bool = False
 
 
@@ -38,17 +60,37 @@ class MessageReplayState(ez.State):
 
 
 class MessageReplay(ez.Unit):
+    """
+    Stream messages from files created by ``MessageLogger``.
+    Stores a queue of files to stream and streams from them in order.
+    """
+
     SETTINGS: MessageReplaySettings
     STATE: MessageReplayState
 
     INPUT_FILE = ez.InputStream(FileReplayMessage)
-    INPUT_PAUSED = ez.InputStream(bool)  # Pause state; True = paused, False = running
-    INPUT_STOP = ez.InputStream(bool)  # True = clear queue
+    """Add a new file to the queue."""
+
+    INPUT_PAUSED = ez.InputStream(bool)
+    """Send ``True`` to pause the stream, ``False`` to restart the stream."""
+
+    INPUT_STOP = ez.InputStream(bool)
+    """
+    Stop the stream. Send ``True`` to also clear the queue.
+    Send ``False`` to reset to the beginning of the current file.
+    """
 
     OUTPUT_MESSAGE = ez.OutputStream(typing.Any)
+    """The output on which the messages from the files will be streamed."""
+
     OUTPUT_TOTAL = ez.OutputStream(int)
+    """
+    Publishes an integer total of messages which have been published on OUTPUT_MESSAGE from a single file.
+    Resets when a file completes.
+    """
 
     OUTPUT_REPLAY_STATUS = ez.OutputStream(ReplayStatusMessage)
+    """Publishes status messages."""
 
     async def initialize(self) -> None:
         self.STATE.replay_files = asyncio.Queue()
@@ -167,10 +209,17 @@ class MessageCollectorState(ez.State):
 
 
 class MessageCollector(ez.Unit):
+    """
+    Collects ``Messages`` into a local list.
+    """
+
     STATE: MessageCollectorState
 
     INPUT_MESSAGE = ez.InputStream(typing.Any)
+    """Send messages here to be collected."""
+
     OUTPUT_MESSAGE = ez.OutputStream(typing.Any)
+    """Messages will pass straight through after being recorded and be published here."""
 
     @ez.subscriber(INPUT_MESSAGE)
     @ez.publisher(OUTPUT_MESSAGE)
@@ -180,4 +229,9 @@ class MessageCollector(ez.Unit):
 
     @property
     def messages(self) -> typing.List[typing.Any]:
+        """
+        Access the list of messages.
+
+        :return: A list of messages which have been collected.
+        """
         return self.STATE.messages

--- a/src/ezmsg/util/messages/axisarray.py
+++ b/src/ezmsg/util/messages/axisarray.py
@@ -12,11 +12,14 @@ import numpy.lib.stride_tricks as nps
 from ezmsg.core.util import either_dict_or_kwargs
 
 # TODO: Typehinting is all wrong in this and 
-# concatenate/transpose should probably not be staticmethods
+#  concatenate/transpose should probably not be staticmethods
 
 
 @dataclass
 class AxisArray:
+    """
+    A lightweight message class comprising a numpy ndarray and its metadata.
+    """
     data: npt.NDArray
     dims: typing.List[str]
     axes: typing.Dict[str, "AxisArray.Axis"] = field(default_factory=dict)
@@ -211,12 +214,12 @@ def slice_along_axis(in_arr: npt.NDArray, sl: typing.Union[slice, int], axis: in
      Use `slice(my_int, my_int+1, None)` to keep the sliced dimension.
 
     Parameters:
-        in_arr (npt.NDArray): The input array to be sliced.
-        sl (Union[slice, int]): The slice object or integer index to use for slicing.
-        axis (int): The axis along which to slice the array.
+        in_arr: The input array to be sliced.
+        sl: The slice object or integer index to use for slicing.
+        axis: The axis along which to slice the array.
 
     Returns:
-        npt.NDArray: The sliced array (view).
+        The sliced array (view).
 
     Raises:
         ValueError: If the axis value is invalid for the input array.
@@ -232,20 +235,22 @@ def slice_along_axis(in_arr: npt.NDArray, sl: typing.Union[slice, int], axis: in
 def sliding_win_oneaxis(in_arr: npt.NDArray, nwin: int, axis: int) -> npt.NDArray:
     """
     Generates a view of an array using a sliding window of specified length along a specified axis of the input array.
-    This is a slightly optimized version of nps.sliding_window_view with a few important differences.
-    * This only accepts a single nwin and a single axis, thus we can skip some checks.
-    * The new `win` axis precedes immediately the original target axis, unlike sliding_window_view where the
-     target axis is moved to the end of the output.
-    Combine this with slice_along_axis(..., sl=slice(None, None, step), axis=axis) to step the window
-     by more than 1 sample at a time.
+    This is a slightly optimized version of nps.sliding_window_view with a few important differences:
 
-    Parameters:
-        in_arr (npt.NDArray): The input array.
-        nwin (int): The size of the sliding window.
-        axis (int): The axis along which the sliding window will be applied.
+    - This only accepts a single nwin and a single axis, thus we can skip some checks.
+    - The new `win` axis precedes immediately the original target axis, unlike sliding_window_view where the
+        target axis is moved to the end of the output.
+
+    Combine this with slice_along_axis(..., sl=slice(None, None, step), axis=axis) to step the window
+        by more than 1 sample at a time.
+
+    Args:
+        in_arr: The input array.
+        nwin: The size of the sliding window.
+        axis: The axis along which the sliding window will be applied.
 
     Returns:
-        npt.NDArray: A view to the input array with the sliding window applied.
+        A view to the input array with the sliding window applied.
 
     Note: There is a known edge case when nwin == shape[axis] + 1. While this should raise
         an error because the window is larger than the input, the implementation ends up

--- a/src/ezmsg/util/terminate.py
+++ b/src/ezmsg/util/terminate.py
@@ -10,7 +10,7 @@ from typing import Optional, Any
 
 class TerminateOnTimeoutSettings(ez.Settings):
     """
-    Settings for ``TerminateOnTimeout`` Unit.
+    Settings for :obj:`TerminateOnTimeout` Unit.
 
     Args:
         time: Terminate if no message has been received in this time (sec)
@@ -53,7 +53,7 @@ class TerminateOnTimeout(ez.Unit):
 
 class TerminateOnTotalSettings(ez.Settings):
     """
-    Settings for ``TerminateOnTotal`` Unit.
+    Settings for :obj:`TerminateOnTotal` Unit.
 
     Args:
         total: The total number of messages to terminate after.

--- a/src/ezmsg/util/terminate.py
+++ b/src/ezmsg/util/terminate.py
@@ -9,8 +9,15 @@ from typing import Optional, Any
 
 
 class TerminateOnTimeoutSettings(ez.Settings):
-    time: float = 2.0  # Terminate if no message has been received in this time (sec)
-    poll_rate: float = 4.0  # Probably no good reason to mess with this (Hz)
+    """
+    Settings for ``TerminateOnTimeout`` Unit.
+
+    Args:
+        time: Terminate if no message has been received in this time (sec)
+        poll_rate: Hz.
+    """
+    time: float = 2.0
+    poll_rate: float = 4.0
 
 
 class TerminateOnTimeoutState(ez.State):
@@ -18,10 +25,15 @@ class TerminateOnTimeoutState(ez.State):
 
 
 class TerminateOnTimeout(ez.Unit):
+    """
+    End a pipeline execution when a certain amount of time has passed without receiving a message.
+    """
+
     SETTINGS: TerminateOnTimeoutSettings
     STATE: TerminateOnTimeoutState
 
     INPUT = ez.InputStream(Any)
+    """Send messages here."""
 
     @ez.subscriber(INPUT)
     async def keepalive(self, _: Any) -> None:
@@ -40,6 +52,12 @@ class TerminateOnTimeout(ez.Unit):
 
 
 class TerminateOnTotalSettings(ez.Settings):
+    """
+    Settings for ``TerminateOnTotal`` Unit.
+
+    Args:
+        total: The total number of messages to terminate after.
+    """
     total: Optional[int] = None
 
 
@@ -49,11 +67,21 @@ class TerminateOnTotalState(ez.State):
 
 
 class TerminateOnTotal(ez.Unit):
+    """
+    End a pipeline execution once a certain number of messages have been received.
+    """
+
     SETTINGS: TerminateOnTotalSettings
     STATE: TerminateOnTotalState
 
     INPUT_MESSAGE = ez.InputStream(Any)
+    """Send messages here."""
+
     INPUT_TOTAL = ez.InputStream(int)
+    """
+    Change the total number of messages to terminate after.
+    If this number has already been reached, termination will occur immediately.
+    """
 
     def initialize(self) -> None:
         self.STATE.total = self.SETTINGS.total


### PR DESCRIPTION
* Most of the prior API and Utils docs has been moved into the src docstrings and the docs are now populated with `autodocs`.
* Added many new docstrings to modules in `sigproc`
* Generated new docs from `sigproc` docstrings.
* `[source]` links back to GitHub.
* I tried to link objects to eachother but this was hit-or-miss.

This is a very large PR but there are absolutely no code changes (unless you count Sphinx conf.py).

IMO, the best way to review it would be to check out the branch, build the docs, and explore a bit.