### PR TITLE
Bugfix: `ezmsg serve` is now venv compatible

### DIFF
--- a/src/ezmsg/core/command.py
+++ b/src/ezmsg/core/command.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import base64
 import asyncio
 import argparse
@@ -97,7 +98,7 @@ async def run_command(cmd: str, graph_address: Address, shm_address: Address) ->
 
     elif cmd == "start":
         popen = subprocess.Popen(
-            ["python", "-m", "ezmsg.core", "serve", f"--address={graph_address}"]
+            [sys.executable, "-m", "ezmsg.core", "serve", f"--address={graph_address}"]
         )
 
         while True:


### PR DESCRIPTION
In certain circumstances, `ezmsg serve` would fork a new subprocess with a different python environment (possibly even system python).  Now we use the same executable.