### PR TITLE
Support a "labels" field in AxisInfo if present. 

### DIFF
--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/aggregate.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/aggregate.py
@@ -82,9 +82,14 @@ def ranged_aggregate(
                     inds = np.where(np.logical_and(ax_vec >= start, ax_vec <= stop))[0]
                     mids.append(np.mean(inds) * target_axis.gain + target_axis.offset)
                     slices.append(np.s_[inds[0]:inds[-1] + 1])
-                out_axis = AxisArray.Axis(
-                    unit=target_axis.unit, offset=mids[0], gain=(mids[1] - mids[0]) if len(mids) > 1 else 1.0
-                )
+                out_ax_kwargs = {
+                    "unit": target_axis.unit,
+                    "offset": mids[0],
+                    "gain": (mids[1] - mids[0]) if len(mids) > 1 else 1.0
+                }
+                if hasattr(target_axis, "labels"):
+                    out_ax_kwargs["labels"] = [f"{_[0]} - {_[1]}" for _ in bands]
+                out_axis = replace(target_axis, **out_ax_kwargs)
 
             agg_func = AGGREGATORS[operation]
             out_data = [


### PR DESCRIPTION
ezmsg-lsl has a [SpaceAxis that I patch into AxisArray](https://github.com/labstreaminglayer/ezmsg-lsl/blob/62d1458bb335b82d7d7b5c7930d5770c4463ee70/src/ezmsg/lsl/units.py#L13-L23), and SpaceAxis has a `labels` field. This solves an issues that we discussed in #43 

Units that transform the AxisArray in a way that modifies the length of the dimension with the "labels" field, should probably also modify the labels, if present! This PR does that for Units that I'm aware of that modify the shape of the array along axes other than "time".

For `affine_transform`, it's difficult to know what the new labels should be so in most cases they are just dropped. However, if the `affine_transform` has rows or columns of zeros then we can get a good guess at thew new labels.