### PR TITLE
Fix downsample

### DIFF
--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/downsample.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/downsample.py
@@ -1,18 +1,19 @@
+import copy
 from dataclasses import replace
 import traceback
-from typing import AsyncGenerator, Optional, Generator
+import typing
 
 import numpy as np
 
-from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.messages.axisarray import AxisArray, slice_along_axis
 from ezmsg.util.generator import consumer
 import ezmsg.core as ez
 
 
 @consumer
 def downsample(
-        axis: Optional[str] = None, factor: int = 1
-) -> Generator[AxisArray, AxisArray, None]:
+        axis: typing.Optional[str] = None, factor: int = 1
+) -> typing.Generator[AxisArray, AxisArray, None]:
     """
     Construct a generator that yields a downsampled version of the data .send() to it.
     Downsampled data simply comprise every `factor`th sample.
@@ -35,7 +36,8 @@ def downsample(
     axis_arr_out = AxisArray(np.array([]), dims=[""])
 
     # state variables
-    s_idx = 0
+    s_idx: int = 0  # Index of the next msg's first sample into the virtual rotating ds_factor counter.
+    template: typing.Optional[AxisArray] = None
 
     while True:
         axis_arr_in = yield axis_arr_out
@@ -45,20 +47,36 @@ def downsample(
         axis_info = axis_arr_in.get_axis(axis)
         axis_idx = axis_arr_in.get_axis_idx(axis)
 
-        samples = np.arange(axis_arr_in.data.shape[axis_idx]) + s_idx
-        samples = samples % factor
-        s_idx = samples[-1] + 1
+        if template is None:
+            # Reset state variables
+            s_idx = 0
+            # Template used as a convenient struct for holding metadata and size-zero data.
+            template = copy.deepcopy(axis_arr_in)
+            template.axes[axis].gain *= factor
+            template.data = slice_along_axis(template.data, slice(None, 0, None), axis=axis_idx)
+
+        n_samples = axis_arr_in.data.shape[axis_idx]
+        samples = np.arange(s_idx, s_idx + n_samples) % factor
+        if n_samples > 0:
+            # Update state for next iteration.
+            s_idx = samples[-1] + 1
 
         pub_samples = np.where(samples == 0)[0]
         if len(pub_samples) > 0:
-            new_axes = {ax_name: axis_arr_in.get_axis(ax_name) for ax_name in axis_arr_in.dims}
-            new_offset = axis_info.offset + (axis_info.gain * pub_samples[0].item())
-            new_gain = axis_info.gain * factor
-            new_axes[axis] = replace(axis_info, gain=new_gain, offset=new_offset)
-            down_data = np.take(axis_arr_in.data, pub_samples, axis=axis_idx)
-            axis_arr_out = replace(axis_arr_in, data=down_data, dims=axis_arr_in.dims, axes=new_axes)
+            # Update the template directly, because we want
+            #  future size-0 msgs to have approx. correct offset.
+            update_ax = template.axes[axis]
+            update_ax.offset = axis_info.offset + axis_info.gain * pub_samples[0].item()
+            axis_arr_out = replace(
+                template,
+                data=slice_along_axis(axis_arr_in.data, pub_samples, axis=axis_idx),
+                axes={**template.axes, axis: replace(update_ax, offset=update_ax.offset)}
+            )
+            template.axes[axis].offset = axis_info.offset + axis_info.gain * (n_samples + 1)
         else:
-            axis_arr_out = None
+            # This iteration did not yield any samples. Return a size-0 array
+            #  with time offset expected for _next_ sample.
+            axis_arr_out = template
 
 
 class DownsampleSettings(ez.Settings):
@@ -66,13 +84,13 @@ class DownsampleSettings(ez.Settings):
     Settings for :obj:`Downsample` node.
     See :obj:`downsample` documentation for a description of the parameters.
     """
-    axis: Optional[str] = None
+    axis: typing.Optional[str] = None
     factor: int = 1
 
 
 class DownsampleState(ez.State):
     cur_settings: DownsampleSettings
-    gen: Generator
+    gen: typing.Generator
 
 
 class Downsample(ez.Unit):
@@ -100,13 +118,13 @@ class Downsample(ez.Unit):
 
     @ez.subscriber(INPUT_SIGNAL, zero_copy=True)
     @ez.publisher(OUTPUT_SIGNAL)
-    async def on_signal(self, msg: AxisArray) -> AsyncGenerator:
+    async def on_signal(self, msg: AxisArray) -> typing.AsyncGenerator:
         if self.STATE.cur_settings.factor < 1:
             raise ValueError("Downsample factor must be at least 1 (no downsampling)")
 
         try:
             out_msg = self.STATE.gen.send(msg)
-            if out_msg is not None:
+            if out_msg.data.size > 0:
                 yield self.OUTPUT_SIGNAL, out_msg
         except (StopIteration, GeneratorExit):
             ez.logger.debug(f"Downsample closed in {self.address}")

--- a/extensions/ezmsg-sigproc/tests/test_downsample.py
+++ b/extensions/ezmsg-sigproc/tests/test_downsample.py
@@ -9,7 +9,7 @@ from ezmsg.util.messages.axisarray import AxisArray
 from ezmsg.util.messagegate import MessageGate, MessageGateSettings
 from ezmsg.util.messagelogger import MessageLogger, MessageLoggerSettings
 from ezmsg.util.messagecodec import message_log
-from ezmsg.sigproc.downsample import Downsample, DownsampleSettings
+from ezmsg.sigproc.downsample import downsample, Downsample, DownsampleSettings
 from ezmsg.sigproc.synth import Counter, CounterSettings
 
 from util import get_test_fn
@@ -18,6 +18,50 @@ from ezmsg.util.terminate import TerminateOnTimeoutSettings as TerminateTestSett
 from ezmsg.util.debuglog import DebugLog
 
 from typing import Optional, List
+
+
+@pytest.mark.parametrize("block_size", [1, 5, 10, 20])
+@pytest.mark.parametrize("factor", [1, 2, 3])
+def test_downsample_core(block_size: int, factor: int):
+    in_fs = 19.0
+    test_dur = 4.0
+    n_channels = 2
+    n_features = 3
+    num_samps = int(np.ceil(test_dur * in_fs))
+    num_msgs = int(np.ceil(num_samps / block_size))
+    sig = np.arange(num_samps * n_channels * n_features).reshape(num_samps, n_channels, n_features)
+    tvec = np.arange(num_samps) / in_fs
+
+    def msg_generator():
+        for msg_ix in range(num_msgs):
+            msg_sig = sig[msg_ix*block_size:(msg_ix+1)*block_size]
+            msg_idx = msg_sig[0, 0, 0] / (n_channels * n_features)
+            msg_offs = msg_idx / in_fs
+            msg = AxisArray(
+                data=msg_sig,
+                dims=["time", "ch", "feat"],
+                axes={"time": AxisArray.Axis.TimeAxis(fs=in_fs, offset=msg_offs)}
+            )
+            yield msg
+
+    proc = downsample(axis="time", factor=factor)
+    out_msgs = []
+    for msg in msg_generator():
+        res = proc.send(msg)
+        if res.data.size:
+            out_msgs.append(res)
+
+    # Assert correctness of gain
+    assert all(msg.axes["time"].gain == factor / in_fs for msg in out_msgs)
+
+    # Assert messages have the correct timestamps
+    expected_offsets = np.cumsum([0] + [_.data.shape[0] for _ in out_msgs]) * factor / in_fs
+    actual_offsets = np.array([_.axes["time"].offset for _ in out_msgs])
+    assert np.allclose(actual_offsets, expected_offsets[:-1])
+
+    # Compare returned values to expected values.
+    allres_msg = AxisArray.concatenate(*out_msgs, dim="time")
+    assert np.array_equal(allres_msg.data, sig[::factor])
 
 
 class DownsampleSystemSettings(ez.Settings):
@@ -65,8 +109,8 @@ class DownsampleSystem(ez.Collection):
         )
 
 
-@pytest.mark.parametrize("block_size", [1, 5, 10, 20])
-@pytest.mark.parametrize("factor", [1, 2, 3])
+@pytest.mark.parametrize("block_size", [10])
+@pytest.mark.parametrize("factor", [3])
 def test_downsample_system(
     block_size: int, factor: int, test_name: Optional[str] = None
 ):


### PR DESCRIPTION
* New unit tests for core (generator function) processing
* accommodate size-0 arrays
* when there is no output, return size-0 arrays instead of None
* slight optim. using template struct -- this approach is abandoned in a future PR so don't dwell on it.

ETA:
This also fixes a bug! Prior to this PR, the downsample generator would not make proper copies and would overwrite shared fields in long-passed messages.