### PR TITLE
sigproc optimization

### DIFF
--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/aggregate.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/aggregate.py
@@ -82,9 +82,14 @@ def ranged_aggregate(
                     inds = np.where(np.logical_and(ax_vec >= start, ax_vec <= stop))[0]
                     mids.append(np.mean(inds) * target_axis.gain + target_axis.offset)
                     slices.append(np.s_[inds[0]:inds[-1] + 1])
-                out_axis = AxisArray.Axis(
-                    unit=target_axis.unit, offset=mids[0], gain=(mids[1] - mids[0]) if len(mids) > 1 else 1.0
-                )
+                out_ax_kwargs = {
+                    "unit": target_axis.unit,
+                    "offset": mids[0],
+                    "gain": (mids[1] - mids[0]) if len(mids) > 1 else 1.0
+                }
+                if hasattr(target_axis, "labels"):
+                    out_ax_kwargs["labels"] = [f"{_[0]} - {_[1]}" for _ in bands]
+                out_axis = replace(target_axis, **out_ax_kwargs)
 
             agg_func = AGGREGATORS[operation]
             out_data = [

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/downsample.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/downsample.py
@@ -1,18 +1,19 @@
+import copy
 from dataclasses import replace
 import traceback
-from typing import AsyncGenerator, Optional, Generator
+import typing
 
 import numpy as np
 
-from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.messages.axisarray import AxisArray, slice_along_axis
 from ezmsg.util.generator import consumer
 import ezmsg.core as ez
 
 
 @consumer
 def downsample(
-        axis: Optional[str] = None, factor: int = 1
-) -> Generator[AxisArray, AxisArray, None]:
+        axis: typing.Optional[str] = None, factor: int = 1
+) -> typing.Generator[AxisArray, AxisArray, None]:
     """
     Construct a generator that yields a downsampled version of the data .send() to it.
     Downsampled data simply comprise every `factor`th sample.
@@ -35,7 +36,8 @@ def downsample(
     axis_arr_out = AxisArray(np.array([]), dims=[""])
 
     # state variables
-    s_idx = 0
+    s_idx: int = 0  # Index of the next msg's first sample into the virtual rotating ds_factor counter.
+    template: typing.Optional[AxisArray] = None
 
     while True:
         axis_arr_in = yield axis_arr_out
@@ -45,20 +47,36 @@ def downsample(
         axis_info = axis_arr_in.get_axis(axis)
         axis_idx = axis_arr_in.get_axis_idx(axis)
 
-        samples = np.arange(axis_arr_in.data.shape[axis_idx]) + s_idx
-        samples = samples % factor
-        s_idx = samples[-1] + 1
+        if template is None:
+            # Reset state variables
+            s_idx = 0
+            # Template used as a convenient struct for holding metadata and size-zero data.
+            template = copy.deepcopy(axis_arr_in)
+            template.axes[axis].gain *= factor
+            template.data = slice_along_axis(template.data, slice(None, 0, None), axis=axis_idx)
+
+        n_samples = axis_arr_in.data.shape[axis_idx]
+        samples = np.arange(s_idx, s_idx + n_samples) % factor
+        if n_samples > 0:
+            # Update state for next iteration.
+            s_idx = samples[-1] + 1
 
         pub_samples = np.where(samples == 0)[0]
         if len(pub_samples) > 0:
-            new_axes = {ax_name: axis_arr_in.get_axis(ax_name) for ax_name in axis_arr_in.dims}
-            new_offset = axis_info.offset + (axis_info.gain * pub_samples[0].item())
-            new_gain = axis_info.gain * factor
-            new_axes[axis] = replace(axis_info, gain=new_gain, offset=new_offset)
-            down_data = np.take(axis_arr_in.data, pub_samples, axis=axis_idx)
-            axis_arr_out = replace(axis_arr_in, data=down_data, dims=axis_arr_in.dims, axes=new_axes)
+            # Update the template directly, because we want
+            #  future size-0 msgs to have approx. correct offset.
+            update_ax = template.axes[axis]
+            update_ax.offset = axis_info.offset + axis_info.gain * pub_samples[0].item()
+            axis_arr_out = replace(
+                template,
+                data=slice_along_axis(axis_arr_in.data, pub_samples, axis=axis_idx),
+                axes={**template.axes, axis: replace(update_ax, offset=update_ax.offset)}
+            )
+            template.axes[axis].offset = axis_info.offset + axis_info.gain * (n_samples + 1)
         else:
-            axis_arr_out = None
+            # This iteration did not yield any samples. Return a size-0 array
+            #  with time offset expected for _next_ sample.
+            axis_arr_out = template
 
 
 class DownsampleSettings(ez.Settings):
@@ -66,13 +84,13 @@ class DownsampleSettings(ez.Settings):
     Settings for :obj:`Downsample` node.
     See :obj:`downsample` documentation for a description of the parameters.
     """
-    axis: Optional[str] = None
+    axis: typing.Optional[str] = None
     factor: int = 1
 
 
 class DownsampleState(ez.State):
     cur_settings: DownsampleSettings
-    gen: Generator
+    gen: typing.Generator
 
 
 class Downsample(ez.Unit):
@@ -100,13 +118,13 @@ class Downsample(ez.Unit):
 
     @ez.subscriber(INPUT_SIGNAL, zero_copy=True)
     @ez.publisher(OUTPUT_SIGNAL)
-    async def on_signal(self, msg: AxisArray) -> AsyncGenerator:
+    async def on_signal(self, msg: AxisArray) -> typing.AsyncGenerator:
         if self.STATE.cur_settings.factor < 1:
             raise ValueError("Downsample factor must be at least 1 (no downsampling)")
 
         try:
             out_msg = self.STATE.gen.send(msg)
-            if out_msg is not None:
+            if out_msg.data.size > 0:
                 yield self.OUTPUT_SIGNAL, out_msg
         except (StopIteration, GeneratorExit):
             ez.logger.debug(f"Downsample closed in {self.address}")

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/filter.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/filter.py
@@ -1,14 +1,13 @@
 import asyncio
-import typing
-
+import copy
 from dataclasses import dataclass, replace, field
-
-import ezmsg.core as ez
-import scipy.signal
+import typing
 
 import numpy as np
 import numpy.typing as npt
+import scipy.signal
 
+import ezmsg.core as ez
 from ezmsg.util.messages.axisarray import AxisArray
 from ezmsg.util.generator import consumer
 
@@ -95,7 +94,8 @@ def filtergen(
             zi = np.tile(zi[zi_expand], n_tile)
 
         dat_out, zi = filt_func(*coefs, dat_in, axis=axis_idx, zi=zi)
-        axis_arr_out = replace(axis_arr_in, data=dat_out)
+        axis_arr_out = copy.copy(axis_arr_in)
+        axis_arr_out.data = dat_out
 
 
 class FilterSettingsBase(ez.Settings):

--- a/extensions/ezmsg-sigproc/src/ezmsg/sigproc/window.py
+++ b/extensions/ezmsg-sigproc/src/ezmsg/sigproc/window.py
@@ -1,3 +1,4 @@
+import copy
 from dataclasses import replace
 import traceback
 from typing import AsyncGenerator, Optional, Tuple, List, Generator
@@ -68,7 +69,7 @@ def windowing(
     shift_deficit: int = 0  # Number of incoming samples to ignore. Only relevant when shift > window.
     b_1to1 = window_shift is None
     newaxis_warned: bool = b_1to1
-    out_template: Optional[AxisArray] = None  # Template for building return values.
+    out_newaxis: Optional[AxisArray.Axis] = None
 
     while True:
         axis_arr_in = yield axis_arr_out
@@ -132,55 +133,37 @@ def windowing(
                 shift_deficit -= n_skip
 
         # Prepare reusable parts of output
-        if out_template is None:
-            template_data_shape = (axis_arr_in.data.shape[:axis_idx]
-                                   + (0, window_samples)
-                                   + axis_arr_in.data.shape[axis_idx + 1:])
-            out_dims = axis_arr_in.dims[:axis_idx] + [newaxis] + axis_arr_in.dims[axis_idx:]
-            out_axes = {
-                **axis_arr_in.axes,
-                axis: replace(axis_info, offset=0.0),  # Sliced axis is relative to newaxis offset
-                newaxis: AxisArray.Axis(
-                    unit=axis_info.unit,
-                    gain=0.0 if b_1to1 else axis_info.gain * window_shift_samples,
-                    offset=0.0  # offset modified below
-                )
-            }
-            out_template = replace(
-                axis_arr_in,
-                data=np.zeros(template_data_shape, dtype=axis_arr_in.data.dtype),
-                dims=out_dims,
-                axes=out_axes
+        if out_newaxis is None:
+            out_newaxis = AxisArray.Axis(
+                unit=axis_info.unit,
+                gain=0.0 if b_1to1 else axis_info.gain * window_shift_samples,
+                offset=0.0  # offset modified per-msg below
             )
 
         # Generate outputs.
+        axis_arr_out = copy.copy(axis_arr_in)
+        axis_arr_out.dims = axis_arr_in.dims[:axis_idx] + [newaxis] + axis_arr_in.dims[axis_idx:]
+        # Preliminary copy of axes without the axes that we are modifying.
+        axis_arr_out.axes = {k: v for k, v in axis_arr_out.axes.items() if k not in [newaxis, axis]}
+        # Update windowed axis so that its offset is relative to the new axis
+        axis_arr_out.axes[axis] = copy.copy(axis_info)
+        axis_arr_out.axes[axis].offset = 0.0  # TODO: If we have `anchor_newest=True` then offset should be -win_dur
+        # How we update .data and .axes[newaxis] depends on the windowing mode.
+        # Note: We update out_newaxis in place because we want our state to reflect the latest timestamp.
+        #  It will have to be copied into axis_arr_out.axes to prevent downstream mutation effects.
         if b_1to1:
             # one-to-one mode -- Each send yields exactly one window containing only the most recent samples.
             buffer = slice_along_axis(buffer, np.s_[-window_samples:], axis_idx)
-            axis_arr_out = replace(
-                    out_template,
-                    data=np.expand_dims(buffer, axis=axis_idx),
-                    axes={
-                        **out_axes,
-                        newaxis: replace(
-                            out_axes[newaxis],
-                            offset=buffer_offset[-window_samples]
-                        )
-                    }
-            )
+            axis_arr_out.data = np.expand_dims(buffer, axis=axis_idx)
+            # We update out_newaxis in place because we want our state to reflect the latest timestamp
+            out_newaxis.offset = buffer_offset[-window_samples]
         elif buffer.shape[axis_idx] >= window_samples:
             # Deterministic window shifts.
             win_view = sliding_win_oneaxis(buffer, window_samples, axis_idx)
             win_view = slice_along_axis(win_view, np.s_[::window_shift_samples], axis_idx)
+            axis_arr_out.data = win_view
             offset_view = sliding_win_oneaxis(buffer_offset, window_samples, 0)[::window_shift_samples]
-            axis_arr_out = replace(
-                out_template,
-                data=win_view,
-                axes={
-                    **out_axes,
-                    newaxis: replace(out_axes[newaxis], offset=offset_view[0, 0])
-                }
-            )
+            out_newaxis.offset = offset_view[0, 0]
 
             # Drop expired beginning of buffer and update shift_deficit
             multi_shift = window_shift_samples * win_view.shape[axis_idx]
@@ -188,7 +171,15 @@ def windowing(
             buffer = slice_along_axis(buffer, np.s_[multi_shift:], axis_idx)
         else:
             # Not enough data to make a new window. Return empty data.
-            axis_arr_out = out_template
+            empty_data_shape = (
+                    axis_arr_in.data.shape[:axis_idx]
+                    + (0, window_samples)
+                    + axis_arr_in.data.shape[axis_idx + 1:]
+            )
+            axis_arr_out.data = np.zeros(empty_data_shape, dtype=axis_arr_in.data.dtype)
+
+        # out_newaxis was modified above, but we need to make a copy of it in our output.
+        axis_arr_out.axes[newaxis] = copy.copy(out_newaxis)
 
 
 class WindowSettings(ez.Settings):
@@ -230,7 +221,7 @@ class Window(ez.Unit):
             zero_pad_until=self.STATE.cur_settings.zero_pad_until
         )
 
-    @ez.subscriber(INPUT_SIGNAL)
+    @ez.subscriber(INPUT_SIGNAL, zero_copy=True)
     @ez.publisher(OUTPUT_SIGNAL)
     async def on_signal(self, msg: AxisArray) -> AsyncGenerator:
         try:
@@ -244,17 +235,14 @@ class Window(ez.Unit):
                 win_axis = out_msg.axes["win"]
                 offsets = np.arange(out_msg.data.shape[axis_idx]) * win_axis.gain + win_axis.offset
                 for msg_ix in range(out_msg.data.shape[axis_idx]):
-                    yield self.OUTPUT_SIGNAL, replace(
-                        msg,
-                        data=slice_along_axis(out_msg.data, msg_ix, axis_idx),
-                        axes={
-                            **msg.axes,
-                            self.STATE.cur_settings.axis: replace(
-                                msg.axes[self.STATE.cur_settings.axis],
-                                offset=offsets[msg_ix]
-                            ),
-                        }
-                    )
+                    _out_msg = copy.copy(out_msg)
+                    _out_msg.data = slice_along_axis(_out_msg.data, msg_ix, axis_idx)
+                    _out_msg.dims = _out_msg.dims[:axis_idx] + _out_msg.dims[axis_idx + 1:]
+                    _out_axinfo = copy.copy(_out_msg.axes[self.STATE.cur_settings.axis])
+                    _out_axinfo.offset = offsets[msg_ix]
+                    _out_msg.axes = {k: v for k, v in msg.axes.items() if k != self.STATE.cur_settings.axis}
+                    _out_msg.axes[self.STATE.cur_settings.axis] = _out_axinfo
+                    yield self.OUTPUT_SIGNAL, _out_msg
         except (StopIteration, GeneratorExit):
             ez.logger.debug(f"Window closed in {self.address}")
         except Exception:

--- a/extensions/ezmsg-sigproc/tests/resources/optim_axis_array_mods.ipynb
+++ b/extensions/ezmsg-sigproc/tests/resources/optim_axis_array_mods.ipynb
@@ -1,0 +1,664 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e32c04512bcc5bf",
+   "metadata": {},
+   "source": [
+    "# Optimizing AxisArray manipulations\n",
+    "\n",
+    "I frequently have to remind myself of a few things when working with AxisArrays.\n",
+    "\n",
+    "* Modifying a single field will affect all other references to this object, which could be in other branches of the pipeline.\n",
+    "* The `axes` field is a dict and modifying it will affect all other references to this `axes` dict.\n",
+    "* `deepcopy` is super slow and usually unnecessary because we often only modify 1 or 2 fields.\n",
+    "\n",
+    "So I came up with a general pattern to transform an AxisArray object that does not use `deepcopy` yet breaks the links to other references on the manipulated fields. The general rules are as follows:\n",
+    "\n",
+    "1. The outgoing message must (out_msg) be a new instance.\n",
+    "2. The out_msg `axes` must be a new dictionary if ANY value is to be modified.\n",
+    "3. Values in `axes` might be mutable references themselves, so modify-by-replacement.\n",
+    "\n",
+    "I use this notebook to remind myself of the problem and to profile the different possible solutions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "initial_id",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-06-02T13:51:33.315070Z",
+     "start_time": "2024-06-02T13:51:33.188532Z"
+    },
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import copy\n",
+    "from dataclasses import replace\n",
+    "\n",
+    "import numpy as np\n",
+    "from ezmsg.util.messages.axisarray import AxisArray\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "505713ffcc88fd3a",
+   "metadata": {},
+   "source": [
+    "## Generate inputs\n",
+    "\n",
+    "We start by generating input messages. We also create a copy of each message's time axis .offset, so we can later check to see a change to the output message's offset affects the input message."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "e1c265caa409a7db",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-06-02T13:51:34.192213Z",
+     "start_time": "2024-06-02T13:51:34.120535Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated 2048 messages\n"
+     ]
+    }
+   ],
+   "source": [
+    "def create_inputs(freq_units=\"Hz\"):\n",
+    "    n_chans = 20\n",
+    "    n_freqs = 100\n",
+    "    data_dur = 30.0\n",
+    "    fs = 1024.0\n",
+    "\n",
+    "    n_samples = int(data_dur * fs)\n",
+    "    data = np.arange(n_samples * n_chans * n_freqs).reshape(n_samples, n_chans, n_freqs)\n",
+    "    n_msgs = int(data_dur / 2)\n",
+    "\n",
+    "    offset = 0\n",
+    "    messages = []\n",
+    "    for arr in np.array_split(data, n_samples // n_msgs):\n",
+    "        messages.append(\n",
+    "            AxisArray(\n",
+    "                arr,\n",
+    "                dims=[\"time\", \"ch\", \"freq\"],\n",
+    "                axes={\n",
+    "                    \"time\": AxisArray.Axis.TimeAxis(fs=fs, offset=offset),\n",
+    "                    \"freq\": AxisArray.Axis(gain=1.0, offset=0.0, unit=freq_units)\n",
+    "                }\n",
+    "            )\n",
+    "        )\n",
+    "        offset += arr.shape[0] / fs\n",
+    "    print(f\"Generated {len(messages)} messages\")\n",
+    "    return messages\n",
+    "\n",
+    "\n",
+    "in_msgs = create_inputs()\n",
+    "# Make a copy of the offsets for future \n",
+    "t0s = np.array([_.axes[\"time\"].offset for _ in in_msgs])\n",
+    "assert all([t0 == ax_arr.axes[\"time\"].offset for t0, ax_arr in zip(t0s, in_msgs)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "543ea8aa87eb03bb",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-06-02T13:51:34.979870Z",
+     "start_time": "2024-06-02T13:51:34.976317Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Let's make sure that modifying an offset does not modify our baseline.\n",
+    "in_msgs[-1].axes[\"time\"].offset = -11.11\n",
+    "assert t0s[-1] != in_msgs[-1].axes[\"time\"].offset \n",
+    "in_msgs[-1].axes[\"time\"].offset = t0s[-1]  # Set it back"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bafef19fd225592e",
+   "metadata": {},
+   "source": [
+    "## Creating and manipulation a new AxisArray"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "236843608d65d649",
+   "metadata": {},
+   "source": [
+    "### deepcopy\n",
+    "\n",
+    "`copy.deepcopy` works as expected. Modifying the `.offset` of the new msg's \"time\" axis has no effect on the original message.\n",
+    "Unfortunately, deepcopy is very expensive, especially when we are only modifying a small subset of fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7b3db7147acda78",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-06-02T13:51:44.829521Z",
+     "start_time": "2024-06-02T13:51:37.219861Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "77.9 ms ± 5.94 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "out_msg = copy.deepcopy(in_msgs[0])\n",
+    "assert out_msg.axes is not in_msgs[0].axes\n",
+    "out_msg.axes[\"time\"].offset = -22.22\n",
+    "assert in_msgs[0].axes[\"time\"].offset == t0s[0]\n",
+    "assert in_msgs[0].axes[\"time\"].offset != out_msg.axes[\"time\"].offset\n",
+    "\n",
+    "# But deepcopy can be expensive\n",
+    "%timeit out_msgs_dc = [copy.deepcopy(_) for _ in in_msgs]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7d808e9410f55e9",
+   "metadata": {},
+   "source": [
+    "### (shallow) copy\n",
+    "\n",
+    "As expected, a shallow copy creates a new object but all mutable fields are shared between the old and the new. As a result, any modification to the new fields will affect the old object.\n",
+    "\n",
+    "As shallow copy is roughly equivalent to initializing a new object with all the fields of the old, we expect the same behaviour when creating outputs that way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "88d6f373a22e53f6",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-06-02T13:51:44.835681Z",
+     "start_time": "2024-06-02T13:51:44.831104Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "out_msg = copy.copy(in_msgs[0])\n",
+    "# Shares the objects underlying the fields.\n",
+    "assert out_msg.axes is in_msgs[0].axes\n",
+    "assert out_msg.data is in_msgs[0].data\n",
+    "# Modify out and see that input changes too.\n",
+    "out_msg.axes[\"time\"].offset = -22.22\n",
+    "assert in_msgs[0].axes[\"time\"].offset == out_msg.axes[\"time\"].offset\n",
+    "assert in_msgs[0].axes[\"time\"].offset != t0s[0]\n",
+    "# Reset the value.\n",
+    "in_msgs[0].axes[\"time\"].offset = t0s[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "17bd9aa5c4b11133",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-06-02T13:51:44.839390Z",
+     "start_time": "2024-06-02T13:51:44.836571Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# What if we create a new message and fill the fields with references?\n",
+    "out_msg = AxisArray(\n",
+    "    data=in_msgs[0].data,\n",
+    "    dims=in_msgs[0].dims,\n",
+    "    axes=in_msgs[0].axes\n",
+    ")\n",
+    "# Shares the objects underlying the fields.\n",
+    "assert out_msg.axes is in_msgs[0].axes\n",
+    "assert out_msg.axes[\"time\"] is in_msgs[0].axes[\"time\"]\n",
+    "assert out_msg.data is in_msgs[0].data\n",
+    "# Modify out and see that input changes too.\n",
+    "out_msg.axes[\"time\"].offset = -33.33\n",
+    "assert in_msgs[0].axes[\"time\"].offset == out_msg.axes[\"time\"].offset\n",
+    "assert in_msgs[0].axes[\"time\"].offset != t0s[0]\n",
+    "# Reset the value.\n",
+    "in_msgs[0].axes[\"time\"].offset = t0s[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a3d614c5bfb3e15",
+   "metadata": {},
+   "source": [
+    "### New from dataclasses `replace`\n",
+    "\n",
+    "It is not obvious how dataclasses `replace` makes the new object, so we demonstrate it here explicitly.\n",
+    "The output is a shallow copy of the input. Furthermore, the \"replaced\" fields are shallow copies of their argument values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d80bdf1e13037245",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-06-02T13:56:25.957912Z",
+     "start_time": "2024-06-02T13:56:25.954677Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "out_msg = replace(\n",
+    "    in_msgs[0],\n",
+    "    axes=in_msgs[0].axes\n",
+    ")\n",
+    "assert out_msg.data is in_msgs[0].data\n",
+    "assert out_msg.axes is in_msgs[0].axes\n",
+    "assert out_msg.axes[\"time\"] is in_msgs[0].axes[\"time\"]\n",
+    "out_msg.axes[\"time\"].offset = -44.44\n",
+    "assert in_msgs[0].axes[\"time\"].offset == out_msg.axes[\"time\"].offset\n",
+    "assert in_msgs[0].axes[\"time\"].offset != t0s[0]\n",
+    "# Reset\n",
+    "in_msgs[0].axes[\"time\"].offset = t0s[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fb312177b5ca71",
+   "metadata": {},
+   "source": [
+    "### New `axes` on init\n",
+    "\n",
+    "If we create a new dictionary to pass to out_msg creation, then we can successfully separate the input axes dict and the output axes dict. HOWEVER, this does not break links between the individual fields!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "bd39058922a31901",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-06-02T02:15:26.872376Z",
+     "start_time": "2024-06-02T02:15:26.868847Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "out_msg = replace(\n",
+    "    in_msgs[0],\n",
+    "    axes={**in_msgs[0].axes}\n",
+    ")\n",
+    "assert out_msg.axes is not in_msgs[0].axes\n",
+    "# Yay, the dict is not the same object!\n",
+    "# However, the time axes are still linked.\n",
+    "assert out_msg.axes[\"time\"] is in_msgs[0].axes[\"time\"]\n",
+    "out_msg.axes[\"time\"].offset = -55.55\n",
+    "assert in_msgs[0].axes[\"time\"].offset != t0s[0]\n",
+    "# Reset\n",
+    "in_msgs[0].axes[\"time\"].offset = t0s[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb841d2fbdf4e0bf",
+   "metadata": {},
+   "source": [
+    "And just for completeness, we show that if we keep the same .axes dict and just create a new entry then we haven't solved the problem because the container is linked. We simply replaced the \"time\" value on both the output and the input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4a03d9ec97f28ac4",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-06-02T14:13:37.672109Z",
+     "start_time": "2024-06-02T14:13:37.668304Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "out_msg = copy.copy(in_msgs[0])\n",
+    "out_msg.axes[\"time\"] = replace(out_msg.axes[\"time\"], offset=-66.66)\n",
+    "# dict remains the same, so we just changed one field in one dict shared across input and output.\n",
+    "assert out_msg.axes[\"time\"] is in_msgs[0].axes[\"time\"]\n",
+    "# Reset\n",
+    "in_msgs[0].axes[\"time\"].offset = t0s[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74293b7b43269524",
+   "metadata": {},
+   "source": [
+    "### General solution\n",
+    "\n",
+    "1. Return message is a new object, potentially initialised via shallow copy of input or template.\n",
+    "2. `.axes` is a new dict.\n",
+    "3. Field (e.g., \"time\") should be modified by replacement only.\n",
+    "\n",
+    "Here is one example of how to achieve this.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "47c2602109c87d26",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-06-02T02:19:59.662672Z",
+     "start_time": "2024-06-02T02:19:59.658505Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "out_msg = copy.copy(in_msgs[0])  # 1. New object\n",
+    "out_msg.axes = {  # New dict \n",
+    "    **in_msgs[0].axes,  # Shallow copy of existing items\n",
+    "    \"time\": copy.copy(in_msgs[0].axes[\"time\"])  # Overwrite time with a copy of the TimeAxis.\n",
+    "}\n",
+    "out_msg.axes[\"time\"].offset = -77.77\n",
+    "assert out_msg.axes is not in_msgs[0].axes\n",
+    "assert out_msg.axes[\"time\"] is not in_msgs[0].axes[\"time\"]\n",
+    "assert in_msgs[0].axes[\"time\"].offset == t0s[0]  # Input offset has not been affected"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48e3200b",
+   "metadata": {},
+   "source": [
+    "## Profiling modifications to AxisArray axis fields\n",
+    "\n",
+    "What is the fastest way to return a message that is similar to the input with a transformed output and a modification to one of the axes entries?\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02928f9a",
+   "metadata": {},
+   "source": [
+    "### Profile creation of axes dict\n",
+    "\n",
+    "There are several ways to make a new dict initialized with an old dict.\n",
+    "\n",
+    "* `new_dict = old_dict.copy()`\n",
+    "* `new_dict = {**old_dict}`\n",
+    "* `new_dict = dict({**old_dict})`\n",
+    "\n",
+    "The 3rd method is strictly slower than the 2nd so we will ignore it.\n",
+    "\n",
+    "We also need to overwrite one of the fields. The 2nd method allows this in the same command.\n",
+    "Additionally, there's a question as to whether we should copy all the old dict fields or only the ones we aren't replacing.\n",
+    "\n",
+    "Let's investigate.\n",
+    "\n",
+    "First, we'll recreate our `in_msgs` but this time give the freq axis a very long string for units to make copying more expensive.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "79bff937",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated 2048 messages\n"
+     ]
+    }
+   ],
+   "source": [
+    "import string\n",
+    "import random\n",
+    "\n",
+    "res = ''.join(random.choices(string.ascii_uppercase +\n",
+    "                             string.digits, k=1000))\n",
+    "in_msgs = create_inputs(freq_units=res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac36bd74",
+   "metadata": {},
+   "source": [
+    "Next we'll try several ways to make a new dict.\n",
+    "Note that in each case we can't assume the class of the axis info object because it might have been a customized subclass."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "54df5f7f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "883 µs ± 13.9 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)\n",
+      "882 µs ± 18.3 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)\n",
+      "965 µs ± 1.65 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)\n",
+      "774 µs ± 1.05 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def new_dict_1(in_msg):\n",
+    "    new_dict = in_msg.axes.copy()\n",
+    "    ax_cls = type(new_dict[\"time\"])\n",
+    "    new_dict[\"time\"] = ax_cls(gain=new_dict[\"time\"].gain, offset=-88.88)\n",
+    "    return new_dict\n",
+    "\n",
+    "def new_dict_2(in_msg):\n",
+    "    new_dict = {**in_msg.axes}\n",
+    "    ax_cls = type(new_dict[\"time\"])\n",
+    "    new_dict[\"time\"] = ax_cls(gain=new_dict[\"time\"].gain, offset=-88.88)\n",
+    "    return new_dict\n",
+    "\n",
+    "def new_dict_3(in_msg):\n",
+    "    ax_cls = type(in_msg.axes[\"time\"])\n",
+    "    return {\n",
+    "        **in_msg.axes,\n",
+    "        \"time\": ax_cls(gain=in_msg.axes[\"time\"].gain, offset=-88.88)\n",
+    "    }\n",
+    "\n",
+    "def new_dict_4(in_msg):\n",
+    "    ax_cls = type(in_msg.axes[\"time\"])\n",
+    "    return {\n",
+    "        **{\n",
+    "            k: (v if k != \"time\" else ax_cls(gain=in_msg.axes[\"time\"].gain, offset=-88.88))\n",
+    "            for k, v in in_msg.axes.items() if k != \"time\"\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "%timeit [new_dict_1(_) for _ in in_msgs]\n",
+    "%timeit [new_dict_2(_) for _ in in_msgs]\n",
+    "%timeit [new_dict_3(_) for _ in in_msgs]\n",
+    "%timeit [new_dict_4(_) for _ in in_msgs]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eae228ba",
+   "metadata": {},
+   "source": [
+    "`new_dict_4` is faster maybe because it has fewer \"copies\", even though the copies are shallow. I might have thought that the check against `k != \"time\"` is expensive.\n",
+    "However, the 4th method is hard to read and is easy to get wrong.\n",
+    "\n",
+    "The other methods are quite close to each other. Method 1 or 2 might be preferred over 4 for readibility."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "564dad3b",
+   "metadata": {},
+   "source": [
+    "Next we consider whether creation of the new TimeAxis field is better done with initialization or `replace`. The nice thing about `replace` is that we don't need to know the input class or the other fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "61b60f06",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.03 ms ± 8.29 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def new_dict_2_replace(in_msg):\n",
+    "    new_dict = {**in_msg.axes}\n",
+    "    new_dict[\"time\"] = replace(new_dict[\"time\"], offset=-88.88)\n",
+    "\n",
+    "\n",
+    "%timeit [new_dict_2_replace(_) for _ in in_msgs]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f49b386",
+   "metadata": {},
+   "source": [
+    "Wow! `replace` was more than twice as slow as creating a new object."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d06c4f8",
+   "metadata": {},
+   "source": [
+    "### Profile creation of object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "94365cdf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.16 ms ± 1.61 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)\n",
+      "2.32 ms ± 10.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def new_axarr_1(in_msg):\n",
+    "    msg_cls = type(in_msg)\n",
+    "    return msg_cls(**in_msg.__dict__)\n",
+    "\n",
+    "\n",
+    "def new_axarr_2(in_msg):\n",
+    "    return replace(in_msg, axes=in_msg.axes)\n",
+    "\n",
+    "\n",
+    "%timeit [new_axarr_1(_) for _ in in_msgs]\n",
+    "%timeit [new_axarr_2(_) for _ in in_msgs]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "9af7d6a1f4a4ea6f",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-06-02T03:51:18.295102Z",
+     "start_time": "2024-06-02T03:51:18.292452Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.91 ms ± 6.55 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n",
+      "4.51 ms ± 16.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def full_modify_1(in_msg):\n",
+    "    msg_cls = type(in_msg)\n",
+    "    out_msg = msg_cls(**in_msg.__dict__)\n",
+    "    ax_cls = type(in_msg.axes[\"time\"])\n",
+    "    out_msg.axes = {\n",
+    "        k: (v if k != \"time\" else ax_cls(gain=in_msg.axes[\"time\"].gain, offset=-88.88))\n",
+    "        for k, v in in_msg.axes.items() if k != \"time\"\n",
+    "    }\n",
+    "    return out_msg\n",
+    "\n",
+    "\n",
+    "def full_modify_2(in_msg):\n",
+    "    return replace(\n",
+    "            in_msg,\n",
+    "            axes={\n",
+    "                **in_msg.axes,\n",
+    "                \"time\": replace(\n",
+    "                    in_msg.axes[\"time\"],\n",
+    "                    offset=-99.99\n",
+    "                )\n",
+    "            }\n",
+    "        )\n",
+    "    \n",
+    "\n",
+    "%timeit [full_modify_1(_) for _ in in_msgs]\n",
+    "%timeit [full_modify_2(_) for _ in in_msgs]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a02b5df0",
+   "metadata": {},
+   "source": [
+    "0.9 vs 2.2 µs per message (2048 messages per loop)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.19"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/extensions/ezmsg-sigproc/tests/test_downsample.py
+++ b/extensions/ezmsg-sigproc/tests/test_downsample.py
@@ -9,7 +9,7 @@ from ezmsg.util.messages.axisarray import AxisArray
 from ezmsg.util.messagegate import MessageGate, MessageGateSettings
 from ezmsg.util.messagelogger import MessageLogger, MessageLoggerSettings
 from ezmsg.util.messagecodec import message_log
-from ezmsg.sigproc.downsample import Downsample, DownsampleSettings
+from ezmsg.sigproc.downsample import downsample, Downsample, DownsampleSettings
 from ezmsg.sigproc.synth import Counter, CounterSettings
 
 from util import get_test_fn
@@ -18,6 +18,50 @@ from ezmsg.util.terminate import TerminateOnTimeoutSettings as TerminateTestSett
 from ezmsg.util.debuglog import DebugLog
 
 from typing import Optional, List
+
+
+@pytest.mark.parametrize("block_size", [1, 5, 10, 20])
+@pytest.mark.parametrize("factor", [1, 2, 3])
+def test_downsample_core(block_size: int, factor: int):
+    in_fs = 19.0
+    test_dur = 4.0
+    n_channels = 2
+    n_features = 3
+    num_samps = int(np.ceil(test_dur * in_fs))
+    num_msgs = int(np.ceil(num_samps / block_size))
+    sig = np.arange(num_samps * n_channels * n_features).reshape(num_samps, n_channels, n_features)
+    tvec = np.arange(num_samps) / in_fs
+
+    def msg_generator():
+        for msg_ix in range(num_msgs):
+            msg_sig = sig[msg_ix*block_size:(msg_ix+1)*block_size]
+            msg_idx = msg_sig[0, 0, 0] / (n_channels * n_features)
+            msg_offs = msg_idx / in_fs
+            msg = AxisArray(
+                data=msg_sig,
+                dims=["time", "ch", "feat"],
+                axes={"time": AxisArray.Axis.TimeAxis(fs=in_fs, offset=msg_offs)}
+            )
+            yield msg
+
+    proc = downsample(axis="time", factor=factor)
+    out_msgs = []
+    for msg in msg_generator():
+        res = proc.send(msg)
+        if res.data.size:
+            out_msgs.append(res)
+
+    # Assert correctness of gain
+    assert all(msg.axes["time"].gain == factor / in_fs for msg in out_msgs)
+
+    # Assert messages have the correct timestamps
+    expected_offsets = np.cumsum([0] + [_.data.shape[0] for _ in out_msgs]) * factor / in_fs
+    actual_offsets = np.array([_.axes["time"].offset for _ in out_msgs])
+    assert np.allclose(actual_offsets, expected_offsets[:-1])
+
+    # Compare returned values to expected values.
+    allres_msg = AxisArray.concatenate(*out_msgs, dim="time")
+    assert np.array_equal(allres_msg.data, sig[::factor])
 
 
 class DownsampleSystemSettings(ez.Settings):
@@ -65,8 +109,8 @@ class DownsampleSystem(ez.Collection):
         )
 
 
-@pytest.mark.parametrize("block_size", [1, 5, 10, 20])
-@pytest.mark.parametrize("factor", [1, 2, 3])
+@pytest.mark.parametrize("block_size", [10])
+@pytest.mark.parametrize("factor", [3])
 def test_downsample_system(
     block_size: int, factor: int, test_name: Optional[str] = None
 ):


### PR DESCRIPTION
Note that the first 2 commits in this PR are already in other PRs in #123 and #127. I included them here because there would be conflicts otherwise. If those 2 PRs get merged then this PR will be a little easier to parse.

What the 3rd commit does:

Following my comments in #124 , I went through all of the sigproc modules and refactored them to create new msg objects because it turns out that shallow-copy + modification is faster than `replace`. This is shown explicitly in the new notebook added to `extensions/tests/resources/`.

Then, confident that we're now making proper copies and not mutating shared objects, I turned on `zero_copy=True` for as many of these Units as I could.